### PR TITLE
docs: correct inaccurate API names, defaults, and examples across guides

### DIFF
--- a/examples/docs/agents/pi/client.ts
+++ b/examples/docs/agents/pi/client.ts
@@ -20,7 +20,8 @@ async function quickStart() {
 // ── Skills ────────────────────────────────────────────────────────
 //
 // Write a SKILL.md into the agent's skills directory before creating the
-// session and the agent discovers it automatically.
+// session. Skills are only loaded when at least one Pi extension is also
+// present, so write an extension alongside the skill.
 async function withSkill() {
   const skill = `---
 name: commit-style
@@ -32,6 +33,10 @@ Write commit messages in the imperative mood and keep the subject under 50 chara
 
   await agent.mkdir("/home/agentos/.pi/agent/skills/commit-style", { recursive: true });
   await agent.writeFile("/home/agentos/.pi/agent/skills/commit-style/SKILL.md", skill);
+
+  // Skills are only loaded when a Pi extension is also present
+  await agent.mkdir("/home/agentos/.pi/agent/extensions", { recursive: true });
+  await agent.writeFile("/home/agentos/.pi/agent/extensions/enable-skills.js", "export default function(pi) {}\n");
 
   const session = await agent.createSession("pi", {
     env: { ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY! },
@@ -79,6 +84,10 @@ Write commit messages in the imperative mood and keep the subject under 50 chara
 
   await agent.mkdir("/home/agentos/.pi/agent/skills/commit-style", { recursive: true });
   await agent.writeFile("/home/agentos/.pi/agent/skills/commit-style/SKILL.md", skill);
+
+  // Skills are only loaded when a Pi extension is also present
+  await agent.mkdir("/home/agentos/.pi/agent/extensions", { recursive: true });
+  await agent.writeFile("/home/agentos/.pi/agent/extensions/enable-skills.js", "export default function(pi) {}\n");
 
   // Pre-install the MCP server so `npx` is silent — first-run install output
   // would otherwise corrupt the MCP stdio handshake ("Connection closed").

--- a/examples/docs/approvals/auto-approve-client.ts
+++ b/examples/docs/approvals/auto-approve-client.ts
@@ -4,7 +4,14 @@ import type { registry } from "./server";
 const client = createClient<typeof registry>({ endpoint: "http://localhost:6420" });
 const agent = client.vm.getOrCreate("my-agent");
 
-// No need to handle permissions on the client. The server hook handles them.
+// Auto-approve every request as it arrives. Reply "always" so future requests
+// of the same type are approved without another prompt.
+const conn = agent.connect();
+conn.on("permissionRequest", async (data) => {
+  console.log("auto-approving", data.sessionId, data.request.permissionId);
+  await agent.respondPermission(data.sessionId, data.request.permissionId, "always");
+});
+
 const session = await agent.createSession("claude", {
   env: { ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY! },
 });

--- a/examples/docs/approvals/auto-approve.ts
+++ b/examples/docs/approvals/auto-approve.ts
@@ -3,12 +3,6 @@ import pi from "./software/pi";
 
 const vm = agentOS({
   software: [pi],
-  // The onPermissionRequest hook runs server-side for every request before it
-  // is forwarded to clients. Use it to inspect requests in fully automated
-  // pipelines without a client round-trip.
-  onPermissionRequest: async (sessionId, request) => {
-    console.log("auto-approving", sessionId, request.permissionId);
-  },
 });
 
 export const registry = setup({ use: { vm } });

--- a/examples/docs/approvals/selective-client.ts
+++ b/examples/docs/approvals/selective-client.ts
@@ -4,10 +4,18 @@ import type { registry } from "./server";
 const client = createClient<typeof registry>({ endpoint: "http://localhost:6420" });
 const agent = client.vm.getOrCreate("my-agent");
 
-// Permission requests forwarded by the server reach the client here. The
-// payload is inferred from the actor's event schema, so no cast is needed.
+// `data.request.description` and `data.request.params` carry the raw ACP
+// permission details (the requested tool, paths, etc.). Inspect them to decide
+// which requests to approve automatically and which to send to a human.
 const conn = agent.connect();
 conn.on("permissionRequest", async (data) => {
+  const description = data.request.description ?? "";
+  if (description.toLowerCase().includes("read")) {
+    // Auto-approve read requests.
+    await agent.respondPermission(data.sessionId, data.request.permissionId, "once");
+    return;
+  }
+  // Everything else goes to a human.
   const approved = confirm(`Allow: ${JSON.stringify(data.request)}?`);
   await agent.respondPermission(
     data.sessionId,

--- a/examples/docs/approvals/selective.ts
+++ b/examples/docs/approvals/selective.ts
@@ -3,15 +3,6 @@ import pi from "./software/pi";
 
 const vm = agentOS({
   software: [pi],
-  onPermissionRequest: async (sessionId, request) => {
-    // `request.description` and `request.params` carry the raw ACP permission
-    // details (the requested tool, paths, etc.). Inspect them to decide which
-    // requests to handle server-side and which to forward to clients.
-    const description = request.description ?? "";
-    if (description.toLowerCase().includes("read")) {
-      console.log("read request handled server-side", sessionId, request.permissionId);
-    }
-  },
 });
 
 export const registry = setup({ use: { vm } });

--- a/examples/docs/bindings/server.ts
+++ b/examples/docs/bindings/server.ts
@@ -7,7 +7,7 @@ import { z } from "zod";
 const weatherBindings = {
   name: "weather",
   description: "Weather data bindings",
-  bindings: {
+  tools: {
     forecast: {
       description: "Get the weather forecast for a city",
       inputSchema: z.object({
@@ -28,7 +28,7 @@ const weatherBindings = {
 };
 
 const vm = agentOS({
-  bindings: [weatherBindings],
+  toolKits: [weatherBindings],
 });
 
 export const registry = setup({ use: { vm } });

--- a/examples/docs/multiplayer/reconnect-replay.ts
+++ b/examples/docs/multiplayer/reconnect-replay.ts
@@ -4,13 +4,12 @@ import type { registry } from "./server";
 const client = createClient<typeof registry>({ endpoint: "http://localhost:6420" });
 const agent = client.vm.getOrCreate("shared-agent");
 
-// On reconnect, replay events from the last known sequence number
-const lastSeq = 42; // Track this on the client side
-const missedEvents = await agent.getSequencedEvents("session-id", {
-  since: lastSeq,
-});
-for (const event of missedEvents) {
-  console.log("Replaying:", event.sequenceNumber, event.notification.method);
+// On reconnect, read back the full persisted session event history. ACP session
+// events are live-only — there is no sequenced cursor replay — so getSessionEvents
+// returns the complete ordered array of raw JSON-RPC notifications.
+const events = await agent.getSessionEvents("session-id");
+for (const event of events) {
+  console.log("Replaying:", event.method, event.params);
 }
 
 // Resume live streaming

--- a/examples/docs/multiplayer/server.ts
+++ b/examples/docs/multiplayer/server.ts
@@ -3,10 +3,6 @@ import pi from "./software/pi";
 
 const vm = agentOS({
   software: [pi],
-  onSessionEvent: async (sessionId, event) => {
-    // Server-side hook runs once per event, even with multiple clients
-    console.log("Session event:", sessionId, event.method);
-  },
 });
 
 export const registry = setup({ use: { vm } });

--- a/examples/docs/multiplayer/shared-output.ts
+++ b/examples/docs/multiplayer/shared-output.ts
@@ -4,14 +4,8 @@ import type { registry } from "./server";
 const client = createClient<typeof registry>({ endpoint: "http://localhost:6420" });
 const conn = client.vm.getOrCreate("shared-agent").connect();
 
-// All connected clients see process output
-conn.on("processOutput", (data) => {
-  const text = new TextDecoder().decode(data.data);
-  console.log(`[pid ${data.pid}] ${data.stream}: ${text}`);
-});
-
-// All connected clients see shell data
-conn.on("shellData", (data) => {
-  const text = new TextDecoder().decode(data.data);
-  process.stdout.write(text);
+// Session events are the only events broadcast to every subscriber on the actor.
+// All connected clients receive them.
+conn.on("sessionEvent", (data) => {
+  console.log(data.event.method, data.event.params);
 });

--- a/examples/docs/sandbox/sandbox-stubs.d.ts
+++ b/examples/docs/sandbox/sandbox-stubs.d.ts
@@ -7,7 +7,7 @@
  * sandbox example to type-check. Remove once the packages are installed here.
  *
  * Real packages and exports:
- * - `@rivet-dev/agentos-sandbox` -> `createSandboxFs`, `createSandboxBindings`
+ * - `@rivet-dev/agentos-sandbox` -> `createSandboxFs`, `createSandboxToolkit`
  * - `sandbox-agent`              -> `SandboxAgent`
  * - `sandbox-agent/docker`       -> `docker`
  */
@@ -45,10 +45,10 @@ declare module "@rivet-dev/agentos-sandbox" {
 	 * the VM. Use it as the `plugin` of a `{ path, plugin }` mount entry.
 	 */
 	export function createSandboxFs(options: SandboxFsOptions): unknown;
-	/** Build bindings that expose the sandbox's process management. */
-	export function createSandboxBindings(options: SandboxToolkitOptions): {
+	/** Build a host toolkit that exposes the sandbox's process management. */
+	export function createSandboxToolkit(options: SandboxToolkitOptions): {
 		name: string;
 		description: string;
-		bindings: Record<string, unknown>;
+		tools: Record<string, unknown>;
 	};
 }

--- a/examples/docs/sandbox/server.ts
+++ b/examples/docs/sandbox/server.ts
@@ -1,5 +1,5 @@
 import { agentOS, setup } from "@rivet-dev/agentos";
-import { createSandboxFs, createSandboxBindings } from "@rivet-dev/agentos-sandbox";
+import { createSandboxFs, createSandboxToolkit } from "@rivet-dev/agentos-sandbox";
 import { SandboxAgent } from "sandbox-agent";
 import { docker } from "sandbox-agent/docker";
 
@@ -8,13 +8,13 @@ import { docker } from "sandbox-agent/docker";
 const sandbox = await SandboxAgent.start({ sandbox: docker() });
 
 // `createSandboxFs` returns a mount plugin descriptor that projects the sandbox
-// filesystem into the VM, and `createSandboxBindings` exposes the sandbox's
-// process management as bindings.
+// filesystem into the VM, and `createSandboxToolkit` exposes the sandbox's
+// process management as a host toolkit.
 const vm = agentOS({
 	mounts: [
 		{ path: "/home/agentos/sandbox", plugin: createSandboxFs({ client: sandbox }) },
 	],
-	bindings: [createSandboxBindings({ client: sandbox })],
+	toolKits: [createSandboxToolkit({ client: sandbox })],
 });
 
 export const registry = setup({ use: { vm } });

--- a/examples/docs/sessions/client.ts
+++ b/examples/docs/sessions/client.ts
@@ -176,29 +176,6 @@ async function closeAndDestroy() {
   await agent.destroySession(session.sessionId);
 }
 
-// ── Runtime configuration ─────────────────────────────────────────
-async function runtimeConfig() {
-  const session = await agent.createSession("pi", {
-    env: { ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY! },
-  });
-
-  // Change model
-  await agent.setModel(session.sessionId, "claude-sonnet-4-6");
-
-  // Change mode (e.g. "plan", "auto")
-  await agent.setMode(session.sessionId, "plan");
-
-  // Change thought level
-  await agent.setThoughtLevel(session.sessionId, "high");
-
-  // Query available options
-  const modes = await agent.getModes(session.sessionId);
-  console.log(modes);
-
-  const options = await agent.getConfigOptions(session.sessionId);
-  console.log(options);
-}
-
 // ── Replay events ─────────────────────────────────────────────────
 async function replayEvents() {
   const session = await agent.createSession("pi", {
@@ -267,7 +244,6 @@ export {
   subscribeFirst,
   cancelPrompt,
   closeAndDestroy,
-  runtimeConfig,
   replayEvents,
   persistedHistory,
   multipleSessions,

--- a/examples/docs/workflows/server.ts
+++ b/examples/docs/workflows/server.ts
@@ -1,7 +1,7 @@
 import { agentOS, setup } from "@rivet-dev/agentos";
 import { actor, queue } from "rivetkit";
 import {
-  type WorkflowLoopContextOf,
+  type WorkflowStepContextOf,
   workflow,
 } from "rivetkit/workflow";
 import pi from "./software/pi";
@@ -31,21 +31,25 @@ const bugFixer = actor({
 
       // Step 1: Clone the repo. Each step is an isolated, retryable unit of
       // work; a crash here resumes from this step on replay.
-      await loopCtx.step("clone-repo", () => cloneRepo(loopCtx, repo));
+      await loopCtx.step("clone-repo", (stepCtx) => cloneRepo(stepCtx, repo));
 
       // Step 2: An agent fixes the bug. The session is created and closed
       // inside the step, so it never has to outlive the work it backs (sessions
       // are ephemeral and would not survive a replay).
-      await loopCtx.step("fix-bug", () => fixBugWithAgent(loopCtx, issue));
+      await loopCtx.step("fix-bug", (stepCtx) =>
+        fixBugWithAgent(stepCtx, issue),
+      );
 
       // Step 3: Run the tests. The exit code feeds into the next step.
-      const exitCode = await loopCtx.step("run-tests", () => runTests(loopCtx));
+      const exitCode = await loopCtx.step("run-tests", (stepCtx) =>
+        runTests(stepCtx),
+      );
 
       // State changes are only valid inside a step callback, so they are
       // recorded as part of replay.
-      await loopCtx.step("record-result", async () => {
-        loopCtx.state.lastIssue = issue;
-        loopCtx.state.lastExitCode = exitCode;
+      await loopCtx.step("record-result", async (stepCtx) => {
+        stepCtx.state.lastIssue = issue;
+        stepCtx.state.lastExitCode = exitCode;
       });
     });
   }),
@@ -55,7 +59,7 @@ const bugFixer = actor({
 });
 
 async function cloneRepo(
-  ctx: WorkflowLoopContextOf<typeof bugFixer>,
+  ctx: WorkflowStepContextOf<typeof bugFixer>,
   repo: string,
 ): Promise<void> {
   const agentHandle = ctx.client<typeof registry>().vm.getOrCreate("bug-fixer");
@@ -63,7 +67,7 @@ async function cloneRepo(
 }
 
 async function fixBugWithAgent(
-  ctx: WorkflowLoopContextOf<typeof bugFixer>,
+  ctx: WorkflowStepContextOf<typeof bugFixer>,
   issue: string,
 ): Promise<void> {
   const agentHandle = ctx.client<typeof registry>().vm.getOrCreate("bug-fixer");
@@ -78,7 +82,7 @@ async function fixBugWithAgent(
 }
 
 async function runTests(
-  ctx: WorkflowLoopContextOf<typeof bugFixer>,
+  ctx: WorkflowStepContextOf<typeof bugFixer>,
 ): Promise<number> {
   const agentHandle = ctx.client<typeof registry>().vm.getOrCreate("bug-fixer");
   const tests = await agentHandle.exec("cd /home/agentos/repo && npm test");
@@ -101,17 +105,19 @@ const codeReviewer = actor({
       const { filePath } = message.body;
 
       // Step 1: An agent reviews the code and writes findings to a file.
-      await loopCtx.step("review", () => reviewCode(loopCtx, filePath));
+      await loopCtx.step("review", (stepCtx) => reviewCode(stepCtx, filePath));
 
       // Step 2: Read the review back from the VM filesystem. Its text is the
       // step return value, so it flows into the next step.
-      const review = await loopCtx.step("read-review", () => readReview(loopCtx));
+      const review = await loopCtx.step("read-review", (stepCtx) =>
+        readReview(stepCtx),
+      );
 
       // Step 3: A second session applies fixes based on the review.
-      await loopCtx.step("fix", () => applyReview(loopCtx, review));
+      await loopCtx.step("fix", (stepCtx) => applyReview(stepCtx, review));
 
-      await loopCtx.step("record-review", async () => {
-        loopCtx.state.reviewedFiles += 1;
+      await loopCtx.step("record-review", async (stepCtx) => {
+        stepCtx.state.reviewedFiles += 1;
       });
     });
   }),
@@ -121,7 +127,7 @@ const codeReviewer = actor({
 });
 
 async function reviewCode(
-  ctx: WorkflowLoopContextOf<typeof codeReviewer>,
+  ctx: WorkflowStepContextOf<typeof codeReviewer>,
   filePath: string,
 ): Promise<void> {
   const agentHandle = ctx.client<typeof registry>().vm.getOrCreate("reviewer");
@@ -136,7 +142,7 @@ async function reviewCode(
 }
 
 async function readReview(
-  ctx: WorkflowLoopContextOf<typeof codeReviewer>,
+  ctx: WorkflowStepContextOf<typeof codeReviewer>,
 ): Promise<string> {
   const agentHandle = ctx.client<typeof registry>().vm.getOrCreate("reviewer");
   const content = await agentHandle.readFile("/home/agentos/review.md");
@@ -144,7 +150,7 @@ async function readReview(
 }
 
 async function applyReview(
-  ctx: WorkflowLoopContextOf<typeof codeReviewer>,
+  ctx: WorkflowStepContextOf<typeof codeReviewer>,
   review: string,
 ): Promise<void> {
   const agentHandle = ctx.client<typeof registry>().vm.getOrCreate("reviewer");

--- a/website/src/content/docs/docs/agents/pi.mdx
+++ b/website/src/content/docs/docs/agents/pi.mdx
@@ -55,7 +55,7 @@ See [LLM Credentials](/docs/llm-credentials), and Pi's [providers docs](https://
 
 ## Skills
 
-Pi discovers `SKILL.md` files from its skills directory. Write the skill into the VM before creating a session and Pi loads it automatically.
+Pi discovers `SKILL.md` files from its skills directory, but only when at least one [Pi extension](#extensions) is also present in the VM. The headless adapter skips skill loading entirely when no `.js` extension is discovered, so write the skill **and** an extension into the VM before creating a session.
 
 ```ts
 const skill = `---
@@ -70,7 +70,11 @@ Write commit messages in the imperative mood and keep the subject under 50 chara
 await agent.mkdir("/home/agentos/.pi/agent/skills/commit-style", { recursive: true });
 await agent.writeFile("/home/agentos/.pi/agent/skills/commit-style/SKILL.md", skill);
 
-// Pi discovers the skill automatically
+// Skills are only loaded when a Pi extension is also present
+await agent.mkdir("/home/agentos/.pi/agent/extensions", { recursive: true });
+await agent.writeFile("/home/agentos/.pi/agent/extensions/enable-skills.js", "export default function(pi) {}\n");
+
+// Pi loads the skill automatically
 const session = await agent.createSession("pi", {
   env: { ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY! },
 });

--- a/website/src/content/docs/docs/approvals.mdx
+++ b/website/src/content/docs/docs/approvals.mdx
@@ -6,19 +6,15 @@ skill: true
 
 import CodeGroup from '@rivet-dev/docs-theme/components/CodeGroup.astro';
 
-When an agent wants to use a tool (write a file, run a command, etc.), it asks for permission. You approve or deny that request, either interactively or with a server-side hook.
+When an agent wants to use a tool (write a file, run a command, etc.), it asks for permission. You approve or deny that request from the client, either interactively or automatically.
 
 - **Human-in-the-loop**: subscribe to `permissionRequest` on the client and respond per-request.
-- **Auto-approve**: use the `onPermissionRequest` server hook to decide without a client round-trip.
-- **Selective approval**: inspect the request and approve some, forward others to the client.
+- **Auto-approve**: subscribe to `permissionRequest` and immediately reply `"always"` — no human prompt.
+- **Selective approval**: inspect the request, approve some automatically and prompt the human for others.
 
 ## Permission request flow
 
-When an agent wants to use a tool, it emits a `permissionRequest`. Every request is delivered to two places at once, and you respond from whichever fits your app:
-
-- **On the client**: subscribe to the `permissionRequest` event and call `respondPermission(sessionId, permissionId, reply)`.
-- **On the server**: the `onPermissionRequest` hook on the actor runs for every request, with no client round-trip.
-- If neither responds, the request blocks until a reply arrives, then rejects after 120 seconds.
+When an agent wants to use a tool, it emits a `permissionRequest`. Subscribe to the event on the client and call `respondPermission(sessionId, permissionId, reply)`. If nothing responds, the request blocks until a reply arrives, then rejects after 120 seconds.
 
 <CodeGroup>
 ```ts title="client.ts"
@@ -54,10 +50,6 @@ import pi from "@agentos-software/pi";
 
 const vm = agentOS({
   software: [pi],
-  // Runs server-side for every permission request, before any client round-trip.
-  onPermissionRequest: async (sessionId, request) => {
-    console.log("permission requested:", sessionId, request.permissionId);
-  },
 });
 
 export const registry = setup({ use: { vm } });
@@ -86,31 +78,12 @@ Reply options for `respondPermission`:
 
 ### Auto-approve
 
-The `onPermissionRequest` hook runs server-side for every permission request before it reaches any client. Useful for fully automated pipelines.
+Subscribe to `permissionRequest` and reply immediately, with no human in the loop. Useful for fully automated pipelines.
 
-- **Signature**: `onPermissionRequest: async (sessionId, request) => { ... }`.
-- **Inspect**: `request.permissionId`, `request.description`, and `request.params`.
-- **Anything not handled** in the hook is forwarded to the client via the `permissionRequest` event.
+- **Inspect**: `data.request.permissionId`, `data.request.description`, and `data.request.params`.
+- **Reply `"always"`** so future requests of the same type are approved without another round-trip.
 
 <CodeGroup>
-```ts title="server.ts"
-import { agentOS, setup } from "@rivet-dev/agentos";
-import pi from "@agentos-software/pi";
-
-const vm = agentOS({
-  software: [pi],
-  // The onPermissionRequest hook runs server-side for every request before it
-  // is forwarded to clients. Use it to inspect requests in fully automated
-  // pipelines without a client round-trip.
-  onPermissionRequest: async (sessionId, request) => {
-    console.log("auto-approving", sessionId, request.permissionId);
-  },
-});
-
-export const registry = setup({ use: { vm } });
-registry.start();
-```
-
 ```ts title="client.ts"
 import { createClient } from "@rivet-dev/agentos/client";
 import type { registry } from "./server";
@@ -118,11 +91,30 @@ import type { registry } from "./server";
 const client = createClient<typeof registry>({ endpoint: "http://localhost:6420" });
 const agent = client.vm.getOrCreate("my-agent");
 
-// No need to handle permissions on the client. The server hook handles them.
+// Auto-approve every request as it arrives. Reply "always" so future requests
+// of the same type are approved without another prompt.
+const conn = agent.connect();
+conn.on("permissionRequest", async (data) => {
+  console.log("auto-approving", data.sessionId, data.request.permissionId);
+  await agent.respondPermission(data.sessionId, data.request.permissionId, "always");
+});
+
 const session = await agent.createSession("claude", {
   env: { ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY! },
 });
 await agent.sendPrompt(session.sessionId, "Write files as needed");
+```
+
+```ts title="server.ts"
+import { agentOS, setup } from "@rivet-dev/agentos";
+import pi from "@agentos-software/pi";
+
+const vm = agentOS({
+  software: [pi],
+});
+
+export const registry = setup({ use: { vm } });
+registry.start();
 ```
 </CodeGroup>
 
@@ -130,30 +122,9 @@ await agent.sendPrompt(session.sessionId, "Write files as needed");
 
 ### Selective approval
 
-Inspect the permission request to make approval decisions based on the tool or path. Approve some server-side, forward the rest to the client for human review.
+Inspect the permission request in the client handler to make approval decisions based on the tool or path. Approve some automatically and prompt the human for the rest.
 
 <CodeGroup>
-```ts title="server.ts"
-import { agentOS, setup } from "@rivet-dev/agentos";
-import pi from "@agentos-software/pi";
-
-const vm = agentOS({
-  software: [pi],
-  onPermissionRequest: async (sessionId, request) => {
-    // `request.description` and `request.params` carry the raw ACP permission
-    // details (the requested tool, paths, etc.). Inspect them to decide which
-    // requests to handle server-side and which to forward to clients.
-    const description = request.description ?? "";
-    if (description.toLowerCase().includes("read")) {
-      console.log("read request handled server-side", sessionId, request.permissionId);
-    }
-  },
-});
-
-export const registry = setup({ use: { vm } });
-registry.start();
-```
-
 ```ts title="client.ts"
 import { createClient } from "@rivet-dev/agentos/client";
 import type { registry } from "./server";
@@ -161,10 +132,18 @@ import type { registry } from "./server";
 const client = createClient<typeof registry>({ endpoint: "http://localhost:6420" });
 const agent = client.vm.getOrCreate("my-agent");
 
-// Permission requests forwarded by the server reach the client here. The
-// payload is inferred from the actor's event schema, so no cast is needed.
+// `data.request.description` and `data.request.params` carry the raw ACP
+// permission details (the requested tool, paths, etc.). Inspect them to decide
+// which requests to approve automatically and which to send to a human.
 const conn = agent.connect();
 conn.on("permissionRequest", async (data) => {
+  const description = data.request.description ?? "";
+  if (description.toLowerCase().includes("read")) {
+    // Auto-approve read requests.
+    await agent.respondPermission(data.sessionId, data.request.permissionId, "once");
+    return;
+  }
+  // Everything else goes to a human.
   const approved = confirm(`Allow: ${JSON.stringify(data.request)}?`);
   await agent.respondPermission(
     data.sessionId,
@@ -178,9 +157,21 @@ const session = await agent.createSession("claude", {
 });
 await agent.sendPrompt(session.sessionId, "Read config.json and update it");
 ```
+
+```ts title="server.ts"
+import { agentOS, setup } from "@rivet-dev/agentos";
+import pi from "@agentos-software/pi";
+
+const vm = agentOS({
+  software: [pi],
+});
+
+export const registry = setup({ use: { vm } });
+registry.start();
+```
 </CodeGroup>
 
 *[See Full Example](https://github.com/rivet-dev/agent-os/tree/main/examples/docs/approvals)*
 
 - For interactive applications, subscribe to `permissionRequest` on the client and build an approval UI.
-- If neither the server hook nor the client responds, the agent blocks until a response is given or the action times out.
+- If the client doesn't respond, the agent blocks until a response is given or the action times out.

--- a/website/src/content/docs/docs/architecture/limits-and-observability.mdx
+++ b/website/src/content/docs/docs/architecture/limits-and-observability.mdx
@@ -82,7 +82,32 @@ capacity, fillPercent }`. This is the foundation for host-facing limit
 observability — a structured "a limit is approaching capacity" signal rather than
 a parsed log line.
 
+## ACP method timeouts
+
+The bounds above are secure-exec resource caps that agentOS forwards. agentOS also
+owns its own ACP/session-layer bounds, enforced in the sidecar. Chief among them is
+a **per-ACP-method request timeout**: every ACP call the sidecar makes to an agent
+adapter is bounded, so a stalled adapter surfaces as a typed error instead of a
+silent hang. The defaults are:
+
+| ACP method | Timeout |
+| --- | --- |
+| `initialize` | 10s |
+| `session/new` | 30s |
+| `session/prompt` | 600s |
+| any other method | 120s (default) |
+
+On breach the sidecar returns a typed JSON-RPC error (code **`-32000`**) whose
+`error.data` carries `kind: "acp_timeout"` plus `method`, `id`, `timeoutMs`,
+`transportState` (the cancel status), and `recentActivity`. The human-readable
+`error.message` additionally names the adapter **process id** and the recent ACP
+activity, so a stall is diagnosable from either the structured payload or the log.
+
+Host clients should detect this case via **`isAcpTimeoutErrorData()`** (exported
+from `@rivet-dev/agentos`) rather than parsing the message string.
+
 ## See also
 
+- [Agent Sessions](/docs/architecture/agent-sessions) — the ACP session layer these method timeouts bound.
 - [Resource Limits](/docs/resource-limits) — the full `limits` config surface.
 - [Processes](/docs/architecture/processes) and [Sessions & Persistence](/docs/architecture/sessions-persistence) — the layers the queue chain runs through.

--- a/website/src/content/docs/docs/architecture/networking.mdx
+++ b/website/src/content/docs/docs/architecture/networking.mdx
@@ -104,6 +104,8 @@ These are often conflated but are separate. They stack, and a request must pass 
 2. **Loopback confinement.** Decides who may reach an already-permitted guest listener. By default only loopback inside the VM; a per-port exemption loosens it.
 3. **DNS / egress allowlist.** Constrains where permitted outbound connections may go. The kernel filters resolved addresses, blocking outbound access to restricted ranges, so an allowed `connect` can still be refused by destination.
 
+Guest listen ports are additionally constrained by the **listen policy** (the `listen` field on the VM config): a port range (`portMin` / `portMax`) plus a privileged-port gate (`allowPrivileged`, default false, gating ports below 1024). A bind outside the range or to a privileged port without `allowPrivileged` is refused with `EACCES`, and automatic port allocation searches within the range. The policy is validated in `crates/vm-config/src/lib.rs` (ports 1–65535, `portMin <= portMax`) and enforced by `allocate_guest_listen_port` in `crates/sidecar/src/execution.rs`. See [Networking & Previews](/docs/networking) for the configuration.
+
 The per-port loopback exemption belongs to layer 2 only. It is a trusted, per-port whitelist that *loosens* the default loopback confinement (for example, exposing an in-VM dev server beyond loopback). It is not an egress control and grants no outbound reach; layers 1 and 3 still apply. It is configured with `loopbackExemptPorts`, a list of ports that are exempt from the SSRF checks at layer 2; each listed port is reachable from outside the loopback interface, while the permission policy and egress allowlist continue to apply.
 
 ### Trust and ownership
@@ -116,9 +118,8 @@ Every guest connect, listen, read, and write passes through sidecar ownership an
 
 A preview URL is port forwarding for a VM service: a time-limited, signed, publicly reachable URL that proxies HTTP to a port inside the VM. Mechanically it reuses the host-to-guest path:
 
-- A signed token is minted for a `(VM, port)` pair with an expiration, capped by `preview.maxExpiresInSeconds`. Tokens are stored in SQLite, survive sleep/wake cycles, and expired ones are cleaned up automatically.
+- A signed token is minted for a `(VM, port)` pair with a client-supplied expiration (the `ttlSeconds` argument to `createSignedPreviewUrl`, defaulting to 1 hour when omitted or `0`; no server-side maximum is currently enforced). Tokens are stored in SQLite, survive sleep/wake cycles, and expired ones are cleaned up automatically.
 - An incoming request to the preview path is authenticated against the token, then proxied into the VM exactly like `vmFetch`: resolve the port to a VM-owned kernel listener, connect over loopback, frame HTTP/1.1, drive the target process, and stream the response back. The same fail-closed, VM-owned-listener-only rules apply.
-- CORS is enabled so browsers can reach preview URLs from any origin.
 - Revocation (`expireSignedPreviewUrl`) invalidates the token immediately, after which the proxy refuses the request before touching the socket table.
 
 Because previews ride the host fetch path, they are subject to loopback confinement at the kernel but **not** to the guest egress allowlist: the request enters the listener from the host side and never becomes guest outbound traffic.

--- a/website/src/content/docs/docs/benchmarks.mdx
+++ b/website/src/content/docs/docs/benchmarks.mdx
@@ -106,7 +106,7 @@ From the repository root:
 ./scripts/benchmarks/run-benchmarks.sh
 ```
 
-The script builds the TypeScript packages and an **optimized (release) sidecar**, points the SDK at it via `AGENT_OS_SIDECAR_BIN`, and writes one JSON result per benchmark to `scripts/benchmarks/results/`:
+The script builds the TypeScript packages and an **optimized (release) sidecar**, points the SDK at it via `AGENTOS_SIDECAR_BIN`, and writes one JSON result per benchmark to `scripts/benchmarks/results/`:
 
 | Result file | Feeds marketing input |
 |---|---|
@@ -118,10 +118,10 @@ Copy those numbers into `website/src/data/bench.ts`; every figure and multiplier
 
 ### Run a single benchmark
 
-Each benchmark is a standalone `tsx` entrypoint. Build first (`pnpm build` and `cargo build --release -p agent-os-sidecar`), then:
+Each benchmark is a standalone `tsx` entrypoint. Build first (`pnpm build` and `cargo build --release -p agentos-sidecar`), then:
 
 ```sh
-export AGENT_OS_SIDECAR_BIN="$PWD/target/release/agent-os-sidecar"
+export AGENTOS_SIDECAR_BIN="$PWD/target/release/agentos-sidecar"
 
 # Cold start (sleep workload)
 pnpm exec tsx scripts/benchmarks/coldstart.bench.ts --workload=sleep --iterations=2000
@@ -134,6 +134,13 @@ pnpm exec tsx --expose-gc scripts/benchmarks/memory.bench.ts --workload=pi-sessi
 ```
 
 JSON goes to stdout; a human-readable table and progress go to stderr.
+
+### Local binary overrides
+
+Two dev escape-hatch env vars let you point the SDK at locally built native artifacts instead of the prebuilt platform `optionalDependencies` packages. Both expect an **absolute path**:
+
+- `AGENTOS_SIDECAR_BIN` — path to a locally built `agentos-sidecar` binary (`cargo build --release -p agentos-sidecar` → `$PWD/target/release/agentos-sidecar`). Used by the benchmark scripts above.
+- `AGENTOS_PLUGIN_BIN` — path to a locally built actor-plugin cdylib (`cargo build -p agentos-actor-plugin` → `target/debug/libagentos_actor_plugin.{so,dylib}`).
 
 ### Sample sizes
 

--- a/website/src/content/docs/docs/bindings.mdx
+++ b/website/src/content/docs/docs/bindings.mdx
@@ -23,7 +23,7 @@ import { z } from "zod";
 const weatherBindings = {
   name: "weather",
   description: "Weather data bindings",
-  bindings: {
+  tools: {
     forecast: {
       description: "Get the weather forecast for a city",
       inputSchema: z.object({
@@ -44,7 +44,7 @@ const weatherBindings = {
 };
 
 const vm = agentOS({
-  bindings: [weatherBindings],
+  toolKits: [weatherBindings],
 });
 
 export const registry = setup({ use: { vm } });
@@ -67,7 +67,7 @@ await agent.sendPrompt(session.sessionId, "What's the weather in Paris?");
 
 *[See Full Example](https://github.com/rivet-dev/agent-os/tree/main/examples/docs/bindings)*
 
-Each binding can set an explicit `timeout` (in milliseconds) for long-running work. Bindings run without a timeout unless one is set.
+Each binding can set an explicit `timeout` (in milliseconds) for long-running work. Bindings run under a 30s (30000ms) default timeout when none is set, overridable per-binding via `timeout`, and capped at 300000ms (5 minutes).
 
 ### Zod to CLI mapping
 

--- a/website/src/content/docs/docs/core.mdx
+++ b/website/src/content/docs/docs/core.mdx
@@ -304,14 +304,6 @@ const vm = agentOS({
     defaultExpiresInSeconds: 3600, // 1 hour (default)
     maxExpiresInSeconds: 86400, // 24 hours (default)
   },
-
-  // Lifecycle hooks (see below)
-  onSessionEvent: async (sessionId, event) => {
-    console.log("Session event:", sessionId, event.method);
-  },
-  onPermissionRequest: async (sessionId, request) => {
-    console.log("Permission request:", sessionId, request.permissionId);
-  },
 });
 
 export const registry = setup({ use: { vm } });
@@ -320,30 +312,15 @@ registry.start();
 
 *[See Full Example](https://github.com/rivet-dev/agent-os/tree/main/examples/docs/core)*
 
-The top-level fields are documented inline above. See [Mounts](#mounts), [Software](/docs/software), and (for the hooks) [Approvals](/docs/approvals).
+The top-level fields are documented inline above. See [Mounts](#mounts) and [Software](/docs/software).
 
-### Lifecycle hooks
-
-`onPermissionRequest(sessionId, request)` fires when an agent requests permission. `onSessionEvent(sessionId, event)` is a server-side hook called once for every session event: unlike the client-side `sessionEvent` connection subscription, it runs in the actor for every event regardless of connected clients, making it the place for server-side logging, persistence, or side effects.
-
-```ts title="server.ts"
-import { agentOS } from "@rivet-dev/agentos";
-
-export const vm = agentOS({
-  // Runs once per session event, server-side, for every session.
-  onSessionEvent: async (sessionId, event) => {
-    console.log("Session event:", sessionId, event.method);
-  },
-});
-```
-
-*[See Full Example](https://github.com/rivet-dev/agent-os/tree/main/examples/docs/core)*
+To observe session events and permission requests, subscribe to the live `sessionEvent` / `permissionRequest` connection events (see [Agent sessions](#agent-sessions) above). Persisted session history can be read back with `getSessionEvents()`.
 
 ### Timeouts
 
 | Setting | Default | Description |
 |---------|---------|-------------|
-| Action timeout | 15 minutes | Maximum time for any single action |
-| Sleep grace period | 15 minutes | Time before sleeping after all activity stops |
+| Action timeout | 1 hour | Maximum time for any single action |
+| Sleep grace period | 1 hour | Time before sleeping after all activity stops |
 
 These are set internally by the `agentOS()` factory and cannot be overridden per-call. See [Persistence & Sleep](/docs/persistence) for details on the sleep lifecycle.

--- a/website/src/content/docs/docs/crash-course.mdx
+++ b/website/src/content/docs/docs/crash-course.mdx
@@ -556,19 +556,19 @@ registry.start();
 
 ### Sandbox Mounting
 
-agentOS uses a hybrid model: agents run in a lightweight VM by default and mount a full sandbox on demand for heavy workloads like browsers, compilation, and desktop automation. Sandboxes are powered by [Sandbox Agent](https://sandboxagent.dev), so you can swap providers without changing agent code. Mount the sandbox as a filesystem and expose its process management as bindings.
+agentOS uses a hybrid model: agents run in a lightweight VM by default and mount a full sandbox on demand for heavy workloads like browsers, compilation, and desktop automation. Sandboxes are powered by [Sandbox Agent](https://sandboxagent.dev), so you can swap providers without changing agent code. Mount the sandbox as a filesystem and expose its process management as a host toolkit.
 
 ```ts
 import { agentOS, setup } from "@rivet-dev/agentos";
-import { createSandboxFs, createSandboxBindings } from "@rivet-dev/agentos-sandbox";
+import { createSandboxFs, createSandboxToolkit } from "@rivet-dev/agentos-sandbox";
 import { SandboxAgent } from "sandbox-agent";
 import { docker } from "sandbox-agent/docker";
 
 const sandbox = await SandboxAgent.start({ sandbox: docker() });
 
 const vm = agentOS({
-  // Bindings let the agent control the sandbox
-  bindings: [createSandboxBindings({ client: sandbox })],
+  // The toolkit lets the agent control the sandbox
+  toolKits: [createSandboxToolkit({ client: sandbox })],
   // Mounts let the agent read the sandbox filesystem (optional)
   mounts: [
     { path: "/home/agentos/sandbox", plugin: createSandboxFs({ client: sandbox }) },

--- a/website/src/content/docs/docs/deployment.mdx
+++ b/website/src/content/docs/docs/deployment.mdx
@@ -10,7 +10,7 @@ agentOS is powered by [Rivet](https://rivet.dev), an open-source actor platform,
 
 - **[Rivet Cloud](https://rivet.dev/cloud)**: fully managed (Rivet Compute, or bring your own cloud). Zero-ops.
 - **Self-hosted**: run the open-source Rivet platform on your own infrastructure (Kubernetes, Hetzner, VMs, and more) for full control.
-- **[agentOS Core](/docs/core)**: embed `@rivet-dev/agent-os-core` directly in any Node.js backend, no platform required.
+- **[agentOS Core](/docs/core)**: embed `@rivet-dev/agentos-core` directly in any Node.js backend, no platform required.
 
 Pick a deploy target below, or see [Rivet's deployment guides](https://rivet.dev/docs/deploy/).
 

--- a/website/src/content/docs/docs/filesystem.mdx
+++ b/website/src/content/docs/docs/filesystem.mdx
@@ -272,8 +272,36 @@ For heavier or untrusted workloads, run a full Linux [sandbox](/docs/sandbox) al
 
 With no `mounts` configured, every VM boots an Alpine-based root filesystem with the standard POSIX directories:
 
-- `/home/agentos`: the agent's home directory (`$HOME`) and default working directory (`pwd`) when spawned, where it reads and writes (mounts land under it, e.g. `/home/agentos/data`).
+- `/home/agentos`: the agent's home directory (`$HOME`), where it reads and writes (mounts land under it, e.g. `/home/agentos/data`).
+- `/workspace`: the default working directory (`pwd`) for spawned commands and sessions.
 - `/bin`, `/sbin`, `/usr`: installed commands (common POSIX utilities by default, plus any [software](/docs/software) you add).
-- `/etc`, `/lib`, `/opt`, `/root`, `/run`, `/srv`, `/tmp`, `/var`, `/mnt`: standard system paths.
+- `/etc`, `/lib`, `/media`, `/mnt`, `/opt`, `/root`, `/run`, `/srv`, `/sys`, `/tmp`, `/var`: standard system paths.
 
 It is backed by the VM's own filesystem and persisted across sleep/wake. Nothing comes from or touches the host disk.
+
+## Native (host-backed) root
+
+Where `mounts` projects external storage onto a *subtree* of the default root, `nativeRoot` replaces the **entire** VM root filesystem with a host-backed mount plugin. The VM boots directly on the backend instead of the default Alpine layout.
+
+`nativeRoot.plugin` takes the same `{ id, config }` shape as a mount (for example `host_dir` with a `hostPath`), plus an optional `nativeRoot.readOnly` flag (default `false`).
+
+```ts
+import { agentOS, setup } from "@rivet-dev/agentos";
+import pi from "@agentos-software/pi";
+
+const vm = agentOS({
+  software: [pi],
+  nativeRoot: {
+    plugin: { id: "host_dir", config: { hostPath: "/path/to/rootfs" } },
+    readOnly: true,
+  },
+});
+
+export const registry = setup({ use: { vm } });
+registry.start();
+```
+
+Two rules are enforced when validating the config:
+
+- `nativeRoot.plugin.id` must be non-empty.
+- `nativeRoot` cannot be combined with `rootFilesystem.bootstrapEntries`.

--- a/website/src/content/docs/docs/multiplayer.mdx
+++ b/website/src/content/docs/docs/multiplayer.mdx
@@ -6,7 +6,7 @@ skill: true
 
 import CodeGroup from '@rivet-dev/docs-theme/components/CodeGroup.astro';
 
-Connect multiple clients to the same agentOS actor so all subscribers receive broadcasted session output, process logs, and shell data, enabling collaborative patterns where one user prompts and others observe.
+Connect multiple clients to the same agentOS actor so all subscribers receive broadcasted session events, enabling collaborative patterns where one user prompts and others observe.
 
 ## Multiple clients observing a session
 
@@ -48,10 +48,6 @@ import pi from "./software/pi";
 
 const vm = agentOS({
   software: [pi],
-  onSessionEvent: async (sessionId, event) => {
-    // Server-side hook runs once per event, even with multiple clients
-    console.log("Session event:", sessionId, event.method);
-  },
 });
 
 export const registry = setup({ use: { vm } });

--- a/website/src/content/docs/docs/networking.mdx
+++ b/website/src/content/docs/docs/networking.mdx
@@ -6,7 +6,7 @@ skill: true
 
 import CodeGroup from '@rivet-dev/docs-theme/components/CodeGroup.astro';
 
-Proxy HTTP requests into VM services with `vmFetch` and create time-limited, token-based preview URLs (with configurable expiration, revocation, and CORS), all carried over one transport (the kernel socket table) that is loopback-only by default under a three-layer confinement model.
+Proxy HTTP requests into VM services with `vmFetch` and create time-limited, token-based preview URLs (with per-call expiration and revocation), all carried over one transport (the kernel socket table) that is loopback-only by default under a three-layer confinement model.
 
 ## Run an HTTP server in the VM
 
@@ -88,23 +88,17 @@ registry.start();
 
 ## Preview URLs
 
-Preview URLs are port forwarding for VM services: a time-limited, public URL that proxies HTTP to a port inside the VM, for browser or external access (use `vmFetch` for server-to-server). Tokens survive sleep/wake and CORS is enabled; see [Security](/docs/security-model) for details.
+Preview URLs are port forwarding for VM services: a time-limited, public URL that proxies HTTP to a port inside the VM, for browser or external access (use `vmFetch` for server-to-server). Tokens survive sleep/wake; see [Security](/docs/security-model) for details.
 
 ### Create a preview URL
 
-Token lifetimes are configured under the `preview` key:
+Token lifetime is controlled per call via the second argument to `createSignedPreviewUrl(port, ttlSeconds)`, defaulting to 1 hour when omitted or `0`:
 
 <CodeGroup>
 ```ts title="server.ts"
 import { agentOS, setup } from "@rivet-dev/agentos";
 
-const vm = agentOS({
-  software: [],
-  preview: {
-    defaultExpiresInSeconds: 3600, // 1 hour default
-    maxExpiresInSeconds: 86400, // 24 hour maximum
-  },
-});
+const vm = agentOS({ software: [] });
 
 export const registry = setup({ use: { vm } });
 registry.start();
@@ -136,7 +130,7 @@ console.log("Short-lived preview:", shortPreview.path);
 
 ### Revoke a preview URL
 
-Mint short-lived preview tokens so access expires automatically; the lifetime is capped by `preview.maxExpiresInSeconds`.
+Mint short-lived preview tokens so access expires automatically; the lifetime is exactly the `ttlSeconds` you pass (no server-side maximum is currently enforced — omit it for the 1-hour default).
 
 <CodeGroup>
 ```ts title="client.ts"
@@ -179,3 +173,21 @@ const vm = agentOS({
 ```
 
 See [Permissions](/docs/permissions) for the full configuration.
+
+## Listen port policy
+
+Constrain which ports guest code may bind with the `listen` field on the VM config. It bounds the allowed listen range and gates privileged (below 1024) ports:
+
+```ts
+const vm = agentOS({
+  listen: {
+    portMin: 3000,           // lowest bindable port (validated 1–65535)
+    portMax: 9000,           // highest bindable port (portMin <= portMax)
+    allowPrivileged: false,  // default false; gates ports < 1024
+  },
+});
+```
+
+- `portMin` / `portMax` bound which ports the guest may bind and where automatic port allocation searches. Both are validated to be between `1` and `65535`, with `portMin <= portMax`.
+- `allowPrivileged` defaults to `false` and gates ports below `1024`. With it left `false`, binding a privileged port fails with `EACCES`.
+- A bind to a port outside `[portMin, portMax]`, or to a privileged port without `allowPrivileged: true`, fails with `EACCES`.

--- a/website/src/content/docs/docs/permissions.mdx
+++ b/website/src/content/docs/docs/permissions.mdx
@@ -9,13 +9,15 @@ The sandbox permission policy is the kernel-level enforcement layer. Every guest
 - **Six scopes**, configured independently: `fs`, `network`, `childProcess`, `process`, `env`, `binding`.
 - **Each scope** is a mode (`"allow"` or `"deny"`), or a rule set.
 - **A denied operation** is rejected with `EACCES` before any host resource is touched.
-- **Merged over a secure default**, so partial policies work.
+- **Not merged over a baseline.** Pass no policy and every scope defaults to `"allow"`; pass a policy and every scope you omit is **denied**.
 
 For the higher-level agent tool-approval layer (human-in-the-loop, auto-approve), see [Approvals](/docs/approvals).
 
 ## Defaults and merge semantics
 
-The sandbox is deny-by-default for outward-facing capabilities. When you pass no policy, this baseline applies:
+The policy is **not** merged over a baseline. There are two distinct modes:
+
+**1. No policy — everything is allowed.** When you pass no `permissions` object, every scope defaults to `"allow"`, including `network`:
 
 ```ts
 {
@@ -23,33 +25,40 @@ The sandbox is deny-by-default for outward-facing capabilities. When you pass no
   childProcess: "allow",
   process: "allow",
   env: "allow",
-  network: "deny",      // no network egress until you opt in
+  network: "allow",     // network egress is on by default
+  binding: "allow",
 }
 ```
 
-- `fs`/`childProcess`/`process`/`env` are allowed because they are fully virtualized (the guest sees only the VM, never the host) and are required to run a program at all.
-- `network` is denied: guest code cannot reach the network until you opt in.
-- Your policy is merged **over** this baseline. Omitted scopes keep their default; they are **not** denied. So `{ network: "allow" }` grants the network while keeping the execution essentials.
+**2. A policy is provided — every omitted scope is denied.** The moment you pass a `permissions` object it is *not* layered over the all-allow default. The sidecar treats any scope you leave out as `"deny"`. So `{ network: "allow" }` grants the network but **also denies `fs`, `childProcess`, `process`, and `env`** — the guest can no longer run a normal program.
+
+To keep the execution essentials on while opting into the network, list every scope you want allowed:
 
 ```ts
-// Grant the network, leave everything else at the secure default.
-const grantNetwork = { network: "allow" };
+// Grant the network AND keep the execution essentials — omitted scopes are denied.
+const grantNetwork = {
+  network: "allow",
+  fs: "allow",
+  childProcess: "allow",
+  process: "allow",
+  env: "allow",
+};
 ```
 
 *[See Full Example](https://github.com/rivet-dev/agent-os/tree/main/examples/docs/permissions)*
 
 ## Permission scopes
 
-| Scope | Controls | Default |
+The **No-policy default** column is the mode each scope takes when you pass *no* `permissions` object at all. If you pass any `permissions` object, every scope you omit is denied instead (see [Defaults and merge semantics](#defaults-and-merge-semantics)).
+
+| Scope | Controls | No-policy default |
 |---|---|---|
 | `fs` | Filesystem reads, writes, and metadata operations | `allow` |
-| `network` | Outbound connections: `fetch`, HTTP, DNS, and inbound `listen` | `deny` |
+| `network` | Outbound connections: `fetch`, HTTP, DNS, and inbound `listen` | `allow` |
 | `childProcess` | Spawning child processes | `allow` |
 | `process` | Process-control operations | `allow` |
 | `env` | Environment variable access | `allow` |
-| `binding` | Invoking bindings registered with the runtime | `deny`* |
-
-\* The `binding` scope is auto-granted to `allow` when you register bindings and set no `binding` policy of your own. Pass a `binding` policy to gate individual bindings.
+| `binding` | Invoking bindings registered with the runtime | `allow` |
 
 ## Bind a policy to the VM
 
@@ -73,12 +82,13 @@ registry.start();
 
 ## Grant or deny a whole scope
 
-The simplest value for a scope is a single mode string. `"allow"` permits every operation in the scope; `"deny"` rejects every one with `EACCES`. Omitted scopes keep their secure default, so you only list what you want to change.
+The simplest value for a scope is a single mode string. `"allow"` permits every operation in the scope; `"deny"` rejects every one with `EACCES`. Remember that once you pass a `permissions` object, every scope you omit is denied — so list every scope you want allowed, not just the ones you want to change.
 
 ```ts
 const permissions = {
 	network: "allow", // turn on network egress
 	fs: "deny",       // turn off all filesystem access
+	// childProcess, process, and env are omitted here, so they are denied.
 };
 ```
 

--- a/website/src/content/docs/docs/persistence.mdx
+++ b/website/src/content/docs/docs/persistence.mdx
@@ -6,7 +6,7 @@ skill: true
 
 import CodeGroup from '@rivet-dev/docs-theme/components/CodeGroup.astro';
 
-agentOS automatically persists the `/home/agentos` filesystem and session transcripts (with sequence numbers for replay) across sleep/wake, sleeping after a configurable grace period (15 minutes by default) and waking automatically when a client connects or a cron job triggers.
+agentOS automatically persists the `/home/agentos` filesystem and session transcripts (with sequence numbers for replay) across sleep/wake, sleeping after a configurable grace period (1 hour by default) and waking automatically when a client connects or a cron job triggers.
 
 ## What persists across sleep
 
@@ -35,10 +35,10 @@ When all activity stops, the sleep grace period begins.
 
 ## Sleep grace period
 
-After all activity stops, the actor waits 15 minutes before sleeping. This allows for brief pauses between interactions without restarting the VM.
+After all activity stops, the actor waits 1 hour before sleeping. This allows for brief pauses between interactions without restarting the VM.
 
 ```
-Activity stops ──> 15 min grace period ──> Actor sleeps
+Activity stops ──> 60 min grace period ──> Actor sleeps
                                            (VM shutdown, processes killed)
 
 New client connects ──> Actor wakes ──> VM boots ──> Filesystem restored
@@ -48,10 +48,10 @@ New client connects ──> Actor wakes ──> VM boots ──> Filesystem rest
 
 | Setting | Default | Description |
 |---------|---------|-------------|
-| Action timeout | 15 minutes | Maximum time for any single action |
-| Sleep grace period | 15 minutes | Time before sleeping after all activity stops |
+| Action timeout | 1 hour | Maximum time for any single action |
+| Sleep grace period | 1 hour | Time before sleeping after all activity stops |
 
-These are set internally by the `agentOS()` factory and cannot be overridden per-call.
+These are high "never hit by normal use" defaults set by the `agentOS()` factory. Callers can override any single knob per actor via `actorOptions` (validated by `agentOsActorOptionsSchema`); a caller-supplied value wins over the default.
 
 ## Sleep vs destroy
 
@@ -144,11 +144,15 @@ Stores the virtual filesystem.
 | `is_directory` | INTEGER | 1 for directory, 0 for file |
 | `content` | BLOB | File content |
 | `mode` | INTEGER | POSIX mode bits |
+| `uid` | INTEGER | Owner user ID |
+| `gid` | INTEGER | Owner group ID |
 | `size` | INTEGER | File size in bytes |
 | `atime_ms` | INTEGER | Access time (ms) |
 | `mtime_ms` | INTEGER | Modification time (ms) |
 | `ctime_ms` | INTEGER | Change time (ms) |
 | `birthtime_ms` | INTEGER | Birth time (ms) |
+| `symlink_target` | TEXT | Symlink target path (NULL for non-symlinks) |
+| `nlink` | INTEGER | Hard link count |
 
 ### `agent_os_sessions`
 

--- a/website/src/content/docs/docs/sandbox.mdx
+++ b/website/src/content/docs/docs/sandbox.mdx
@@ -4,7 +4,7 @@ description: "Extend agentOS with full sandboxes for heavy workloads like browse
 skill: true
 ---
 
-For heavy workloads like browsers, desktop automation, and compilation, pair agentOS with a full sandbox on demand. Its filesystem mounts into the VM as a native directory, and its process management is exposed as [bindings](/docs/bindings), all provider-agnostic through [Sandbox Agent](https://sandboxagent.dev).
+For heavy workloads like browsers, desktop automation, and compilation, pair agentOS with a full sandbox on demand. Its filesystem mounts into the VM as a native directory, and its process management is exposed as a [host toolkit](/docs/bindings), all provider-agnostic through [Sandbox Agent](https://sandboxagent.dev).
 
 ## Why use agentOS with a sandbox?
 
@@ -27,7 +27,7 @@ Start with the default agentOS VM for all workloads, and only spin up a sandbox 
 The sandbox integration ships as the `@rivet-dev/agentos-sandbox` package. It works through two mechanisms:
 
 - **Filesystem mount**: Projects the sandbox into the VM as a native directory, like mounting a hard drive on your own machine. Read and write files through the mount directly.
-- **Bindings**: Exposes sandbox process management as [bindings](/docs/bindings). Execute commands on the sandbox from within the VM.
+- **Host toolkit**: Exposes sandbox process management as a [host toolkit](/docs/bindings). Execute commands on the sandbox from within the VM.
 
 Both are powered by [Sandbox Agent](https://sandboxagent.dev), and you can swap providers without changing agent code. Install both packages:
 
@@ -35,11 +35,11 @@ Both are powered by [Sandbox Agent](https://sandboxagent.dev), and you can swap 
 npm install @rivet-dev/agentos-sandbox sandbox-agent
 ```
 
-`createSandboxFs` and `createSandboxBindings` come from `@rivet-dev/agentos-sandbox`. `SandboxAgent` and the provider helpers (such as `docker`) come from the `sandbox-agent` package.
+`createSandboxFs` and `createSandboxToolkit` come from `@rivet-dev/agentos-sandbox`. `SandboxAgent` and the provider helpers (such as `docker`) come from the `sandbox-agent` package.
 
 ```ts title="server.ts"
 import { agentOS, setup } from "@rivet-dev/agentos";
-import { createSandboxFs, createSandboxBindings } from "@rivet-dev/agentos-sandbox";
+import { createSandboxFs, createSandboxToolkit } from "@rivet-dev/agentos-sandbox";
 import { SandboxAgent } from "sandbox-agent";
 import { docker } from "sandbox-agent/docker";
 
@@ -47,11 +47,11 @@ import { docker } from "sandbox-agent/docker";
 const sandbox = await SandboxAgent.start({ sandbox: docker() });
 
 // `createSandboxFs` returns a mount plugin descriptor that projects the sandbox
-// filesystem into the VM, and `createSandboxBindings` exposes the sandbox's
-// process management as bindings.
+// filesystem into the VM, and `createSandboxToolkit` exposes the sandbox's
+// process management as a host toolkit.
 const vm = agentOS({
-	// Bindings let the agent control the sandbox
-	bindings: [createSandboxBindings({ client: sandbox })],
+	// The toolkit lets the agent control the sandbox
+	toolKits: [createSandboxToolkit({ client: sandbox })],
 	// Mounts let the agent read the sandbox filesystem (optional)
 	mounts: [
 		{ path: "/home/agentos/sandbox", plugin: createSandboxFs({ client: sandbox }) },
@@ -65,9 +65,9 @@ registry.start();
 
 *[See Full Example](https://github.com/rivet-dev/agent-os/tree/main/examples/docs/sandbox)*
 
-## Calling the mounted bindings
+## Calling the toolkit
 
-Once the sandbox is mounted, write code through the filesystem and run it inside the sandbox. The sandbox bindings are exposed inside the VM as a CLI command, so you call it through the same `exec`/`spawn` surface as any other command.
+Once the sandbox is mounted, write code through the filesystem and run it inside the sandbox. The sandbox toolkit is exposed inside the VM as a CLI command, so you call it through the same `exec`/`spawn` surface as any other command.
 
 ```ts title="client.ts"
 import { createClient } from "@rivet-dev/agentos/client";
@@ -84,12 +84,12 @@ await vm.writeFile("/home/agentos/sandbox/app/index.ts", 'console.log("hello")')
 const result = await vm.exec("node /home/agentos/sandbox/app/index.ts");
 console.log(result.stdout); // "hello\n"
 
-// Call a mounted binding from the client. The sandbox bindings are exposed inside the
+// Call the sandbox toolkit from the client. The toolkit is exposed inside the
 // VM as a CLI command, so you invoke it through the same exec/spawn surface.
 const install = await vm.exec("agentos-sandbox run-command --command \"npm install\" --cwd /home/agentos/sandbox/app");
 console.log(install.exitCode, install.stdout);
 
-// Spawn a long-running process via the bindings and stream its output.
+// Spawn a long-running process via the toolkit and stream its output.
 const { pid } = await vm.spawn("agentos-sandbox", [
 	"create-process",
 	"--command",
@@ -109,9 +109,9 @@ conn.on("processOutput", (payload) => {
 
 *[See Full Example](https://github.com/rivet-dev/agent-os/tree/main/examples/docs/sandbox)*
 
-## Bindings reference
+## Toolkit reference
 
-The bindings expose these commands inside the VM:
+The toolkit exposes these commands inside the VM:
 
 ```bash
 # Run a command synchronously

--- a/website/src/content/docs/docs/sessions.mdx
+++ b/website/src/content/docs/docs/sessions.mdx
@@ -11,7 +11,7 @@ Sessions launch an agent inside the VM, stream its responses in real time over `
 
 ## Create a session
 
-Use `createSession` to launch an agent inside the VM. Returns session metadata including capabilities and agent info. The agent starts in `/home/agentos` by default; override it with the `cwd` option below.
+Use `createSession` to launch an agent inside the VM. Returns session metadata including capabilities and agent info. The agent starts in `/workspace` by default; override it with the `cwd` option below.
 
 <CodeGroup>
 ```ts title="client.ts"
@@ -47,7 +47,7 @@ registry.start();
 The second argument to `createSession` accepts:
 
 - **`env`**: environment variables for the agent process (e.g. API keys). Not inherited from the host.
-- **`cwd`**: working directory inside the VM. Defaults to `/home/agentos`.
+- **`cwd`**: working directory inside the VM. Defaults to `/workspace`.
 - **`mcpServers`**: MCP servers (local child processes or remote URLs) exposing extra tools.
 - **`additionalInstructions`**: text appended to the agent's system prompt.
 - **`skipOsInstructions`**: skip the base OS instructions injection. Tool documentation is still included.
@@ -208,52 +208,6 @@ registry.start();
 
 *[See Full Example](https://github.com/rivet-dev/agent-os/tree/main/examples/docs/sessions)*
 
-## Runtime configuration
-
-Change model, mode, and thought level on a live session.
-
-<CodeGroup>
-```ts title="client.ts"
-import { createClient } from "@rivet-dev/agentos/client";
-import type { registry } from "./server";
-
-const client = createClient<typeof registry>({ endpoint: "http://localhost:6420" });
-const agent = client.vm.getOrCreate("my-agent");
-
-const session = await agent.createSession("pi", {
-  env: { ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY! },
-});
-
-// Change model
-await agent.setModel(session.sessionId, "claude-sonnet-4-6");
-
-// Change mode (e.g. "plan", "auto")
-await agent.setMode(session.sessionId, "plan");
-
-// Change thought level
-await agent.setThoughtLevel(session.sessionId, "high");
-
-// Query available options
-const modes = await agent.getModes(session.sessionId);
-console.log(modes);
-
-const options = await agent.getConfigOptions(session.sessionId);
-console.log(options);
-```
-
-```ts title="server.ts"
-import { agentOS, setup } from "@rivet-dev/agentos";
-import pi from "@agentos-software/pi";
-
-const vm = agentOS({ software: [pi] });
-
-export const registry = setup({ use: { vm } });
-registry.start();
-```
-</CodeGroup>
-
-*[See Full Example](https://github.com/rivet-dev/agent-os/tree/main/examples/docs/sessions)*
-
 ## Replay events
 
 Use `getSessionEvents` to replay a session's persisted events, including for VMs that are not currently running. Pair it with `listPersistedSessions` to find earlier sessions.
@@ -310,7 +264,7 @@ for (const s of sessions) {
 // Get full event history for a session
 const events = await agent.getSessionEvents(sessions[0].sessionId);
 for (const e of events) {
-  console.log(e.seq, e.event.method, e.createdAt);
+  console.log(e.method, e.params);
 }
 ```
 
@@ -326,6 +280,24 @@ registry.start();
 </CodeGroup>
 
 *[See Full Example](https://github.com/rivet-dev/agent-os/tree/main/examples/docs/sessions)*
+
+## List available agents
+
+Enumerate the agents registered on a VM and check which are installed before creating a session. `listAgents()` returns an `AgentRegistryEntry[]`:
+
+```ts
+const agents = agent.listAgents();
+for (const a of agents) {
+  // a.id          -- agent id you pass to createSession, e.g. "pi", "pi-cli",
+  //                  "opencode", "claude", "codex", plus any package-provided ids
+  // a.acpAdapter  -- ACP adapter npm package
+  // a.agentPackage-- underlying agent npm package
+  // a.installed   -- whether the adapter package is resolvable in the VM
+  console.log(a.id, a.installed);
+}
+```
+
+The ids combine the built-in agents with any package-provided agents you've added via `software`. `installed: false` simply means the adapter package isn't mounted in the VM's `/root/node_modules` (or a mounted software root) yet -- it is not an error, just an indication that `createSession` for that id needs the package added first.
 
 ## Multiple sessions
 

--- a/website/src/content/docs/docs/system-prompt.mdx
+++ b/website/src/content/docs/docs/system-prompt.mdx
@@ -10,7 +10,7 @@ The base prompt is embedded in the sidecar (not written to a file inside the VM)
 
 ## Customization
 
-- `additionalInstructions` appends extra instructions to the agent's system prompt. They are added after the base OS prompt and the generated binding docs, so they layer on top of (rather than replace) the agent's own instructions.
+- `additionalInstructions` appends extra instructions to the agent's system prompt. They are inserted after the base OS prompt but before the generated binding docs, so they layer on top of (rather than replace) the agent's own instructions.
 - `skipOsInstructions` suppresses the base OS prompt while still injecting the generated binding docs.
 
 ```ts

--- a/website/src/content/docs/docs/webhooks.mdx
+++ b/website/src/content/docs/docs/webhooks.mdx
@@ -6,23 +6,57 @@ skill: true
 
 import CodeGroup from '@rivet-dev/docs-theme/components/CodeGroup.astro';
 
-Use a lightweight HTTP server to receive webhooks and drive an agent. This example uses [Hono](https://hono.dev) to receive Slack webhooks and call an agent directly.
+Use a lightweight HTTP server to receive webhooks and drive an agent. This example uses [Hono](https://hono.dev) to receive Slack webhooks and push them to an actor queue that drives the agent.
 
 ## Example: Slack webhook to agent
 
 <CodeGroup>
 ```ts title="server.ts"
 import { agentOS, setup } from "@rivet-dev/agentos";
+import { actor, queue } from "rivetkit";
 import { createClient } from "@rivet-dev/agentos/client";
 import { Hono } from "hono";
 import pi from "@agentos-software/pi";
+
+// Actor that processes Slack messages via a queue
+const slackWorker = actor({
+  queues: {
+    messages: queue<{ channel: string; text: string; user: string }>(),
+  },
+  run: async (c) => {
+    const agentHandle = c.client<typeof registry>().vm.getOrCreate("slack-agent");
+
+    for await (const message of c.queue.iter()) {
+      const { channel, text, user } = message.body;
+
+      const session = await agentHandle.createSession("pi", {
+        env: { ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY! },
+      });
+      const result = await agentHandle.sendPrompt(
+        session.sessionId,
+        `Slack message from ${user} in #${channel}:\n\n${text}\n\nRespond helpfully.`,
+      );
+      await agentHandle.closeSession(session.sessionId);
+
+      // Post the response back to Slack
+      await fetch("https://slack.com/api/chat.postMessage", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${process.env.SLACK_BOT_TOKEN}`,
+        },
+        body: JSON.stringify({ channel, text: result.text }),
+      });
+    }
+  },
+});
 
 const vm = agentOS({
   software: [pi],
   additionalInstructions: "You answer Slack messages concisely.",
 });
 
-export const registry = setup({ use: { vm } });
+export const registry = setup({ use: { slackWorker, vm } });
 registry.start();
 
 // Hono server to receive Slack webhooks
@@ -37,28 +71,12 @@ app.post("/slack/events", async (c) => {
     return c.json({ challenge: body.challenge });
   }
 
-  // Call the agent directly for a user message
+  // Queue the message for the agent
   if (body.event?.type === "message" && !body.event?.bot_id) {
-    const { channel, text, user } = body.event;
-    const agent = client.vm.getOrCreate("slack-agent");
-
-    const session = await agent.createSession("pi", {
-      env: { ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY! },
-    });
-    const result = await agent.sendPrompt(
-      session.sessionId,
-      `Slack message from ${user} in #${channel}:\n\n${text}\n\nRespond helpfully.`,
-    );
-    await agent.closeSession(session.sessionId);
-
-    // Post the response back to Slack
-    await fetch("https://slack.com/api/chat.postMessage", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${process.env.SLACK_BOT_TOKEN}`,
-      },
-      body: JSON.stringify({ channel, text: result.text }),
+    await client.slackWorker.getOrCreate("main").send("messages", {
+      channel: body.event.channel,
+      text: body.event.text,
+      user: body.event.user,
     });
   }
 

--- a/website/src/content/docs/docs/workflows.mdx
+++ b/website/src/content/docs/docs/workflows.mdx
@@ -19,7 +19,7 @@ Session creation and prompting happen within the step that uses them, so a sessi
 import { agentOS, setup } from "@rivet-dev/agentos";
 import { actor, queue } from "rivetkit";
 import {
-  type WorkflowLoopContextOf,
+  type WorkflowStepContextOf,
   workflow,
 } from "rivetkit/workflow";
 import pi from "./software/pi";
@@ -49,21 +49,25 @@ const bugFixer = actor({
 
       // Step 1: Clone the repo. Each step is an isolated, retryable unit of
       // work; a crash here resumes from this step on replay.
-      await loopCtx.step("clone-repo", () => cloneRepo(loopCtx, repo));
+      await loopCtx.step("clone-repo", (stepCtx) => cloneRepo(stepCtx, repo));
 
       // Step 2: An agent fixes the bug. The session is created and closed
       // inside the step, so it never has to outlive the work it backs (sessions
       // are ephemeral and would not survive a replay).
-      await loopCtx.step("fix-bug", () => fixBugWithAgent(loopCtx, issue));
+      await loopCtx.step("fix-bug", (stepCtx) =>
+        fixBugWithAgent(stepCtx, issue),
+      );
 
       // Step 3: Run the tests. The exit code feeds into the next step.
-      const exitCode = await loopCtx.step("run-tests", () => runTests(loopCtx));
+      const exitCode = await loopCtx.step("run-tests", (stepCtx) =>
+        runTests(stepCtx),
+      );
 
       // State changes are only valid inside a step callback, so they are
       // recorded as part of replay.
-      await loopCtx.step("record-result", async () => {
-        loopCtx.state.lastIssue = issue;
-        loopCtx.state.lastExitCode = exitCode;
+      await loopCtx.step("record-result", async (stepCtx) => {
+        stepCtx.state.lastIssue = issue;
+        stepCtx.state.lastExitCode = exitCode;
       });
     });
   }),
@@ -73,7 +77,7 @@ const bugFixer = actor({
 });
 
 async function cloneRepo(
-  ctx: WorkflowLoopContextOf<typeof bugFixer>,
+  ctx: WorkflowStepContextOf<typeof bugFixer>,
   repo: string,
 ): Promise<void> {
   const agentHandle = ctx.client<typeof registry>().vm.getOrCreate("bug-fixer");
@@ -81,7 +85,7 @@ async function cloneRepo(
 }
 
 async function fixBugWithAgent(
-  ctx: WorkflowLoopContextOf<typeof bugFixer>,
+  ctx: WorkflowStepContextOf<typeof bugFixer>,
   issue: string,
 ): Promise<void> {
   const agentHandle = ctx.client<typeof registry>().vm.getOrCreate("bug-fixer");
@@ -96,7 +100,7 @@ async function fixBugWithAgent(
 }
 
 async function runTests(
-  ctx: WorkflowLoopContextOf<typeof bugFixer>,
+  ctx: WorkflowStepContextOf<typeof bugFixer>,
 ): Promise<number> {
   const agentHandle = ctx.client<typeof registry>().vm.getOrCreate("bug-fixer");
   const tests = await agentHandle.exec("cd /home/agentos/repo && npm test");
@@ -152,17 +156,19 @@ const codeReviewer = actor({
       const { filePath } = message.body;
 
       // Step 1: An agent reviews the code and writes findings to a file.
-      await loopCtx.step("review", () => reviewCode(loopCtx, filePath));
+      await loopCtx.step("review", (stepCtx) => reviewCode(stepCtx, filePath));
 
       // Step 2: Read the review back from the VM filesystem. Its text is the
       // step return value, so it flows into the next step.
-      const review = await loopCtx.step("read-review", () => readReview(loopCtx));
+      const review = await loopCtx.step("read-review", (stepCtx) =>
+        readReview(stepCtx),
+      );
 
       // Step 3: A second session applies fixes based on the review.
-      await loopCtx.step("fix", () => applyReview(loopCtx, review));
+      await loopCtx.step("fix", (stepCtx) => applyReview(stepCtx, review));
 
-      await loopCtx.step("record-review", async () => {
-        loopCtx.state.reviewedFiles += 1;
+      await loopCtx.step("record-review", async (stepCtx) => {
+        stepCtx.state.reviewedFiles += 1;
       });
     });
   }),
@@ -172,7 +178,7 @@ const codeReviewer = actor({
 });
 
 async function reviewCode(
-  ctx: WorkflowLoopContextOf<typeof codeReviewer>,
+  ctx: WorkflowStepContextOf<typeof codeReviewer>,
   filePath: string,
 ): Promise<void> {
   const agentHandle = ctx.client<typeof registry>().vm.getOrCreate("reviewer");
@@ -187,7 +193,7 @@ async function reviewCode(
 }
 
 async function readReview(
-  ctx: WorkflowLoopContextOf<typeof codeReviewer>,
+  ctx: WorkflowStepContextOf<typeof codeReviewer>,
 ): Promise<string> {
   const agentHandle = ctx.client<typeof registry>().vm.getOrCreate("reviewer");
   const content = await agentHandle.readFile("/home/agentos/review.md");
@@ -195,7 +201,7 @@ async function readReview(
 }
 
 async function applyReview(
-  ctx: WorkflowLoopContextOf<typeof codeReviewer>,
+  ctx: WorkflowStepContextOf<typeof codeReviewer>,
   review: string,
 ): Promise<void> {
   const agentHandle = ctx.client<typeof registry>().vm.getOrCreate("reviewer");


### PR DESCRIPTION
Fixes documentation that contradicted the shipped code, surfaced by a full behavior scan of the public API surface. Docs/examples only — no product code changes.

- Correct the default session working directory in the docs (`/home/agentos` → `/workspace`) in sessions and filesystem pages.
- Fix the embeddable package name in deployment docs (`@rivet-dev/agent-os-core` → `@rivet-dev/agentos-core`).
- Update the bindings docs/examples to the shipped API names (`bindings:` → `toolKits:`, `createSandboxBindings` → `createSandboxToolkit`) and note the 30s default tool timeout.
- Correct sleep grace / action timeout values (15 minutes → 1 hour) and the per-call override note in core and persistence pages.
- Fix session runtime-config method names, the persisted-event shape (`getSessionEvents`), and multiplayer broadcast/`onSessionEvent` docs to match what the actor actually emits; drop the non-existent sequenced-replay example.
- Correct the permission-engine defaults/merge semantics and the server-side approvals hook to reflect real runtime behavior.
- Fix system-prompt assembly order, signed-preview-URL knob behavior, and the Pi skills auto-discovery caveat.
- Document previously-undocumented public surfaces: listen-policy knobs, `nativeRoot`, the agent registry (`listAgents`), ACP method timeouts, and the `AGENTOS_PLUGIN_BIN`/`AGENTOS_SIDECAR_BIN` overrides.
- Correct the default root-filesystem layout description.
