### PR TITLE
fix(client,ci): migrate agentos-client to current secure-exec wire API + unblock release pipeline

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -117,7 +117,7 @@ jobs:
             fi
             case "$v" in 0.0.0-*) echo "::error::secure_exec_version must be a real release, not a preview"; exit 1;; esac
             npm view "@secure-exec/core@$v" version >/dev/null
-            curl -sf "https://crates.io/api/v1/crates/secure-exec-sidecar/$v" >/dev/null               || { echo "::error::secure-exec-sidecar@$v is not on crates.io"; exit 1; }
+            curl -sf "https://index.crates.io/se/cu/secure-exec-sidecar" | grep -q "\"vers\":\"$v\"" || { echo "::error::secure-exec-sidecar@$v is not on crates.io"; exit 1; }
             echo "version=$v" >> "$GITHUB_OUTPUT"
             echo "registry_tag=latest" >> "$GITHUB_OUTPUT"
             exit 0
@@ -404,11 +404,14 @@ jobs:
           pnpm --filter=publish exec tsx src/ci/bin.ts bump-versions \
             --version ${{ needs.context.outputs.version }} \
             --version-only
+      - name: Install wasm-pack (for @rivet-dev/agentos-browser wasm build)
+        run: |
+          rustup target add wasm32-unknown-unknown
+          curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - name: Build TypeScript packages
         run: |
           npx turbo build \
             --filter='!@rivet-dev/agentos-playground' \
-            --filter='!@agentos/website' \
             --filter='!./examples/*' \
             --filter='!./examples/quickstart/*'
       - name: Finalize package versions for publish (inject optionalDeps)

--- a/crates/client/src/agent_os.rs
+++ b/crates/client/src/agent_os.rs
@@ -304,6 +304,8 @@ impl AgentOs {
             | wire::ResponsePayload::PersistenceFlushedResponse(_)
             | wire::ResponsePayload::VmFetchResponse(_)
             | wire::ResponsePayload::ExtEnvelope(_)
+            | wire::ResponsePayload::GuestKernelResultResponse(_)
+            | wire::ResponsePayload::ResourceSnapshotResponse(_)
             | wire::ResponsePayload::PackageLinkedResponse(_) => {
                 return Err(ClientError::Sidecar(
                     "unexpected open_session response".to_string(),
@@ -370,6 +372,8 @@ impl AgentOs {
             | wire::ResponsePayload::PersistenceFlushedResponse(_)
             | wire::ResponsePayload::VmFetchResponse(_)
             | wire::ResponsePayload::ExtEnvelope(_)
+            | wire::ResponsePayload::GuestKernelResultResponse(_)
+            | wire::ResponsePayload::ResourceSnapshotResponse(_)
             | wire::ResponsePayload::PackageLinkedResponse(_) => {
                 return Err(ClientError::Sidecar(
                     "unexpected create_vm response".to_string(),
@@ -451,6 +455,8 @@ impl AgentOs {
             | wire::ResponsePayload::PersistenceFlushedResponse(_)
             | wire::ResponsePayload::VmFetchResponse(_)
             | wire::ResponsePayload::ExtEnvelope(_)
+            | wire::ResponsePayload::GuestKernelResultResponse(_)
+            | wire::ResponsePayload::ResourceSnapshotResponse(_)
             | wire::ResponsePayload::PackageLinkedResponse(_) => {
                 return Err(ClientError::Sidecar(
                     "unexpected configure_vm response".to_string(),
@@ -528,6 +534,8 @@ impl AgentOs {
                     | wire::ResponsePayload::PersistenceFlushedResponse(_)
                     | wire::ResponsePayload::VmFetchResponse(_)
                     | wire::ResponsePayload::ExtEnvelope(_)
+                    | wire::ResponsePayload::GuestKernelResultResponse(_)
+                    | wire::ResponsePayload::ResourceSnapshotResponse(_)
                     | wire::ResponsePayload::PackageLinkedResponse(_) => {
                         return Err(ClientError::Sidecar(
                             "unexpected register_host_callbacks response".to_string(),
@@ -633,12 +641,11 @@ impl AgentOs {
             .request_wire(
                 wire_vm_ownership(&inner.connection_id, &inner.session_id, &inner.vm_id),
                 wire::RequestPayload::LinkPackageRequest(wire::LinkPackageRequest {
-                    // The wire `PackageDescriptor` carries `{ name, dir, acpEntrypoint? }`;
-                    // forward all three from the client-side descriptor.
+                    // The wire `PackageDescriptor` carries only `{ dir }`; the
+                    // sidecar reads `name`/`acpEntrypoint` from the package's
+                    // `agentos-package.json` at `dir`.
                     package: wire::PackageDescriptor {
-                        name: descriptor.name,
                         dir: descriptor.dir,
-                        acp_entrypoint: descriptor.acp_entrypoint,
                     },
                 }),
             )
@@ -1039,6 +1046,7 @@ fn serialize_create_vm_config_for_sidecar(
                 // it forwards no snapshot. TODO: expose a snapshot bundle input on
                 // the Rust client config for parity if a Rust consumer needs it.
                 snapshot_userland_code: None,
+                high_resolution_time: None,
             }
         }),
     })
@@ -3614,11 +3622,11 @@ fn build_package_descriptors(
 ) -> Result<Vec<wire::PackageDescriptor>, ClientError> {
     let mut descriptors = Vec::with_capacity(config.packages.len());
     for package in &config.packages {
-        let manifest = read_agentos_package_manifest(&package.dir)?;
+        // Validate the package dir has a manifest, but the wire descriptor now
+        // carries only `dir`; the sidecar re-reads name/acpEntrypoint from it.
+        let _manifest = read_agentos_package_manifest(&package.dir)?;
         descriptors.push(wire::PackageDescriptor {
-            name: manifest.name,
             dir: package.dir.clone(),
-            acp_entrypoint: manifest.agent.and_then(|agent| agent.acp_entrypoint),
         });
     }
     Ok(descriptors)

--- a/crates/client/src/fs.rs
+++ b/crates/client/src/fs.rs
@@ -527,10 +527,16 @@ impl AgentOs {
         let result = self
             .guest_fs_call(Self::fs_request(GuestFilesystemOperation::ReadDir, path))
             .await?;
-        // secure-exec's READ_DIR returns basenames only (`entries: list<str>`);
-        // the typed [`Self::read_dir_with_types`] path derives each entry's type
-        // with a per-child `lstat`.
-        Ok(result.entries.unwrap_or_default())
+        // secure-exec's READ_DIR now returns rich entries (`entries:
+        // list<GuestDirEntry>` with name + is_directory + is_symbolic_link);
+        // this name-only accessor projects the basenames. The richer fields back
+        // the typed [`Self::read_dir_with_types`] path.
+        Ok(result
+            .entries
+            .unwrap_or_default()
+            .into_iter()
+            .map(|entry| entry.name)
+            .collect())
     }
 
     async fn kernel_stat(&self, path: &str) -> Result<VirtualStat> {


### PR DESCRIPTION
Reconciles agent-os with the secure-exec it targets and unblocks the release pipeline. Companion secure-exec PR: rivet-dev/secure-exec#267 (agent pack bin fix + crates.io fixture path).

**Client wire-API migration (the release blocker)**
- `agentos-client` was a regression: the committed `.github/refs/secure-exec` was bumped (#1598–1600) without re-fitting the client, whose last re-fit (d4cbe825) targeted the older secure-exec `0bf7dcb`. It no longer compiled against the ref'd secure-exec.
- Re-fit against the current wire API: `PackageDescriptor` → `{ dir }`; `READ_DIR` entries → `GuestDirEntry.name`; handle the new `ResponsePayload::{GuestKernelResultResponse, ResourceSnapshotResponse}` variants; add `JsRuntimeConfig.high_resolution_time`. Keeps main's newer client features (listMounts / readdirEntries / listSoftware).

**Release-pipeline CI fixes**
- Verify the secure-exec crate via the crates.io **sparse index** (the v1 API now 403s under crates.io's data-access policy).
- Install **wasm-pack** in the publish-npm job so `@rivet-dev/agentos-browser`'s `build:dist-wasm` works.
- Drop the `--filter='!@agentos/website'` turbo filter (website is excluded from the workspace, so the filter matched no package and turbo errored).

**Notes on leaked "do-not-commit" workarounds on main** (context, addressed operationally)
- The `crates/agentos-sidecar-browser` workspace member and the browser wasm build now work because `secure-exec-sidecar-browser` was published to crates.io and wasm-pack is installed in CI.
- The `website`-excluded-from-workspace workaround is worked around by dropping the turbo filter above.

**Pi agent adapter**
- The `createSession("pi")` → `Cannot find module '/unknown/pi-sdk-acp'` failure is fixed by the secure-exec pack change (#267): agent `bin` now points at the real entry file, so published agents keep their entrypoint. Verified: the adapter now boots and runs.
- Remaining (not in this PR): the pi agent then fails resolving its lazy external `@anthropic-ai/sdk` — the snapshot-restored adapter's `require` base doesn't include the package's `node_modules`. That's a secure-exec runtime fix (require resolution must follow the entrypoint symlink to the package's node_modules, like `#225` did for module-mode).
