### PR TITLE
feat: add Command Code CLI package

### DIFF
--- a/.agents/resume
+++ b/.agents/resume
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# This repository has no long-lived services to repair when an orb resumes.

--- a/.agents/setup
+++ b/.agents/setup
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+node_version="22.19.0"
+node_dir="$HOME/.local/share/node-v$node_version"
+
+if [[ ! -x "$node_dir/bin/node" ]]; then
+	archive="node-v$node_version-linux-x64.tar.xz"
+	tmp_dir="$(mktemp -d)"
+	trap 'rm -rf "$tmp_dir"' EXIT
+	curl -fsSLo "$tmp_dir/$archive" "https://nodejs.org/dist/v$node_version/$archive"
+	curl -fsSLo "$tmp_dir/SHASUMS256.txt" "https://nodejs.org/dist/v$node_version/SHASUMS256.txt"
+	(
+		cd "$tmp_dir"
+		grep "  $archive$" SHASUMS256.txt | sha256sum --check --strict
+	)
+	mkdir -p "$(dirname "$node_dir")"
+	tar -xJf "$tmp_dir/$archive" -C "$(dirname "$node_dir")"
+	mv "$(dirname "$node_dir")/node-v$node_version-linux-x64" "$node_dir"
+fi
+
+mkdir -p "$HOME/.local/bin"
+for command in node npm npx corepack; do
+	ln -sfn "$node_dir/bin/$command" "$HOME/.local/bin/$command"
+done
+
+"$node_dir/bin/corepack" prepare pnpm@10.13.1 --activate
+for command in pnpm pnpx; do
+	ln -sfn "$node_dir/bin/$command" "$HOME/.local/bin/$command"
+done
+
+if [[ ! -x "$HOME/.cargo/bin/cargo" ]]; then
+	curl --proto '=https' --tlsv1.2 -fsS https://sh.rustup.rs |
+		sh -s -- -y --profile minimal --default-toolchain stable
+fi
+for command in cargo rustc rustfmt rustup; do
+	ln -sfn "$HOME/.cargo/bin/$command" "$HOME/.local/bin/$command"
+done
+
+cd "$repo_root"
+if [[ ! -f website/vendor/theme/package.json ]]; then
+	theme_dir="$(mktemp -d)"
+	git -C "$theme_dir" init --quiet
+	git -C "$theme_dir" remote add origin https://github.com/rivet-dev/docs-theme.git
+	git -C "$theme_dir" fetch --quiet --depth=1 origin 450c498555135098c6a927adfdf13458be9be22a
+	git -C "$theme_dir" checkout --quiet FETCH_HEAD
+	mkdir -p website/vendor
+	rm -rf website/vendor/theme
+	cp -R "$theme_dir/packages/theme" website/vendor/theme
+	rm -rf "$theme_dir"
+fi
+
+pnpm install --frozen-lockfile
+pnpm --dir website/vendor/theme build

--- a/crates/execution/src/javascript.rs
+++ b/crates/execution/src/javascript.rs
@@ -6871,6 +6871,7 @@ export const chmod = _m.chmod;
 export const chown = _m.chown;
 export const copyFile = _m.copyFile;
 export const cp = _m.cp;
+export const glob = _m.glob;
 export const lchmod = _m.lchmod;
 export const lchown = _m.lchown;
 export const link = _m.link;

--- a/crates/execution/tests/javascript_v8.rs
+++ b/crates/execution/tests/javascript_v8.rs
@@ -1790,13 +1790,16 @@ fn javascript_execution_imports_node_fs_promises_without_hanging() {
             wasm_module_bytes: None,
             inline_code: Some(String::from(
                 r#"
-import fs from "node:fs/promises";
+import fs, { glob } from "node:fs/promises";
 
 if (typeof fs.access !== "function") {
   throw new Error("node:fs/promises did not expose access()");
 }
 if (typeof fs.readFile !== "function") {
   throw new Error("node:fs/promises did not expose readFile()");
+}
+if (typeof fs.glob !== "function" || glob !== fs.glob) {
+  throw new Error("node:fs/promises did not expose glob()");
 }
 "#,
             )),

--- a/crates/v8-runtime/src/execution.rs
+++ b/crates/v8-runtime/src/execution.rs
@@ -121,6 +121,28 @@ pub fn install_high_resolution_time_global(scope: &mut v8::HandleScope, origin: 
     global.define_own_property(scope, key.into(), func.into(), attr);
 }
 
+pub fn install_process_exit_global(scope: &mut v8::HandleScope) {
+    let context = scope.get_current_context();
+    let global = context.global(scope);
+    let template = v8::FunctionTemplate::builder(process_exit_callback).build(scope);
+    let Some(function) = template.get_function(scope) else {
+        return;
+    };
+    let key = v8::String::new(scope, "__secureExecProcessExit").unwrap();
+    let attributes = v8::PropertyAttribute::READ_ONLY | v8::PropertyAttribute::DONT_DELETE;
+    global.define_own_property(scope, key.into(), function.into(), attributes);
+}
+
+fn process_exit_callback(
+    scope: &mut v8::HandleScope,
+    args: v8::FunctionCallbackArguments,
+    _rv: v8::ReturnValue,
+) {
+    let code = args.get(0).int32_value(scope).unwrap_or(0);
+    crate::isolate::set_process_exit(scope, code);
+    scope.terminate_execution();
+}
+
 pub fn install_require_esm_sync_global(scope: &mut v8::HandleScope) {
     let context = scope.get_current_context();
     let global = context.global(scope);

--- a/crates/v8-runtime/src/isolate.rs
+++ b/crates/v8-runtime/src/isolate.rs
@@ -33,6 +33,31 @@ pub struct PromiseRejectState {
     overflow_count: usize,
 }
 
+#[derive(Default)]
+struct ProcessExitState {
+    code: Option<i32>,
+}
+
+pub fn clear_process_exit(isolate: &mut v8::Isolate) {
+    isolate
+        .get_slot_mut::<ProcessExitState>()
+        .expect("process exit state must be installed")
+        .code = None;
+}
+
+pub fn set_process_exit(isolate: &mut v8::Isolate, code: i32) {
+    isolate
+        .get_slot_mut::<ProcessExitState>()
+        .expect("process exit state must be installed")
+        .code = Some(code);
+}
+
+pub fn process_exit_code(isolate: &v8::Isolate) -> Option<i32> {
+    isolate
+        .get_slot::<ProcessExitState>()
+        .and_then(|state| state.code)
+}
+
 impl PromiseRejectState {
     fn record_unhandled(&mut self, promise_id: i32, error: ExecutionError) {
         use std::collections::hash_map::Entry;
@@ -105,6 +130,7 @@ extern "C" fn promise_reject_callback(msg: v8::PromiseRejectMessage) {
 
 pub fn configure_isolate(isolate: &mut v8::OwnedIsolate) {
     isolate.set_slot(PromiseRejectState::default());
+    isolate.set_slot(ProcessExitState::default());
     isolate.set_promise_reject_callback(promise_reject_callback);
 }
 

--- a/crates/v8-runtime/src/session.rs
+++ b/crates/v8-runtime/src/session.rs
@@ -2489,12 +2489,20 @@ fn session_thread(
 
                         let iso = v8_isolate.as_mut().unwrap();
                         iso.cancel_terminate_execution();
+                        isolate::clear_process_exit(iso);
 
                         // Create execution context: Context::new on a snapshot-restored
                         // isolate gives a fresh clone of the snapshot's default context
                         // (bridge IIFE already executed, all infrastructure set up).
                         // On a non-snapshot isolate, this gives a blank context.
                         let exec_context = isolate::create_context(iso);
+
+                        {
+                            let scope = &mut v8::HandleScope::new(iso);
+                            let ctx = v8::Local::new(scope, &exec_context);
+                            let scope = &mut v8::ContextScope::new(scope, ctx);
+                            execution::install_process_exit_global(scope);
+                        }
 
                         if high_resolution_time {
                             let scope = &mut v8::HandleScope::new(iso);
@@ -2802,11 +2810,16 @@ fn session_thread(
                                 &mut bridge_cache,
                             )
                         };
+                        let mut process_exit_code = isolate::process_exit_code(iso);
+                        if process_exit_code.is_some() {
+                            exports = None;
+                            error = None;
+                        }
 
                         // Re-check async ESM completion once immediately so
                         // pure-microtask top-level await settles without
                         // needing a bridge event-loop round-trip.
-                        if mode != 0 && error.is_none() {
+                        if mode != 0 && error.is_none() && process_exit_code.is_none() {
                             let scope = &mut v8::HandleScope::new(iso);
                             let ctx = v8::Local::new(scope, &exec_context);
                             let scope = &mut v8::ContextScope::new(scope, ctx);
@@ -2826,9 +2839,10 @@ fn session_thread(
                         // are visible yet — the module body may have registered
                         // timers, stdin listeners, or child_process handles that
                         // need event loop pumping to deliver their callbacks.
-                        let should_enter_event_loop = !pending.is_empty()
-                            || execution::has_pending_module_evaluation()
-                            || execution::has_pending_script_evaluation();
+                        let should_enter_event_loop = process_exit_code.is_none()
+                            && (!pending.is_empty()
+                                || execution::has_pending_module_evaluation()
+                                || execution::has_pending_script_evaluation());
                         let event_loop_status = if should_enter_event_loop {
                             let scope = &mut v8::HandleScope::new(iso);
                             let ctx = v8::Local::new(scope, &exec_context);
@@ -2849,8 +2863,14 @@ fn session_thread(
                             EventLoopStatus::Completed
                         };
 
-                        let mut terminated =
-                            matches!(event_loop_status, EventLoopStatus::Terminated);
+                        process_exit_code =
+                            process_exit_code.or_else(|| isolate::process_exit_code(iso));
+                        if process_exit_code.is_some() {
+                            exports = None;
+                            error = None;
+                        }
+                        let mut terminated = process_exit_code.is_some()
+                            || matches!(event_loop_status, EventLoopStatus::Terminated);
                         if let EventLoopStatus::Failed(next_code, next_error) = event_loop_status {
                             code = next_code;
                             error = Some(next_error);
@@ -2918,21 +2938,23 @@ fn session_thread(
                                 // Phase 2: pump the event loop for that quiescence wait.
                                 if !pending.is_empty() || execution::has_pending_script_evaluation()
                                 {
-                                    let scope = &mut v8::HandleScope::new(iso);
-                                    let ctx = v8::Local::new(scope, &exec_context);
-                                    let scope = &mut v8::ContextScope::new(scope, ctx);
-                                    let event_loop_status = run_event_loop_with_readiness(
-                                        scope,
-                                        EventLoopSources {
-                                            commands: &rx,
-                                            readiness: &ready_broker,
-                                            readiness_wakes: &ready_rx,
-                                            bridge_responses: Some(&async_response_rx),
-                                            abort: Some(&abort_rx),
-                                            pause: Some(&pause_control),
-                                        },
-                                        &pending,
-                                    );
+                                    let event_loop_status = {
+                                        let scope = &mut v8::HandleScope::new(iso);
+                                        let ctx = v8::Local::new(scope, &exec_context);
+                                        let scope = &mut v8::ContextScope::new(scope, ctx);
+                                        run_event_loop_with_readiness(
+                                            scope,
+                                            EventLoopSources {
+                                                commands: &rx,
+                                                readiness: &ready_broker,
+                                                readiness_wakes: &ready_rx,
+                                                bridge_responses: Some(&async_response_rx),
+                                                abort: Some(&abort_rx),
+                                                pause: Some(&pause_control),
+                                            },
+                                            &pending,
+                                        )
+                                    };
 
                                     if matches!(event_loop_status, EventLoopStatus::Terminated) {
                                         terminated = true;
@@ -2942,6 +2964,13 @@ fn session_thread(
                                     {
                                         code = next_code;
                                         error = Some(next_error);
+                                    }
+                                    process_exit_code = process_exit_code
+                                        .or_else(|| isolate::process_exit_code(iso));
+                                    if process_exit_code.is_some() {
+                                        terminated = true;
+                                        exports = None;
+                                        error = None;
                                     }
                                 }
                             }
@@ -3062,6 +3091,15 @@ fn session_thread(
                                     stack: String::new(),
                                     code: "ERR_SCRIPT_WALL_CLOCK_EXCEEDED".into(),
                                 }),
+                            }
+                        } else if let Some(process_exit_code) = process_exit_code.filter(|_| {
+                            !matches!(abort_reason, Some(ExecutionAbortReason::Terminated))
+                        }) {
+                            RuntimeEvent::ExecutionResult {
+                                session_id,
+                                exit_code: process_exit_code,
+                                exports: None,
+                                error: None,
                             }
                         } else if terminated {
                             RuntimeEvent::ExecutionResult {
@@ -3254,6 +3292,9 @@ fn run_event_loop_with_readiness(
         // passes. Check the durable abort lane before any V8 API call; querying
         // promises or timers on an already-terminated isolate can otherwise
         // spin forever and prevent explicit session destruction from joining.
+        if crate::isolate::process_exit_code(scope).is_some() {
+            return EventLoopStatus::Terminated;
+        }
         if abort_rx.is_some_and(execution_abort_requested) {
             scope.terminate_execution();
             return EventLoopStatus::Terminated;
@@ -3270,6 +3311,9 @@ fn run_event_loop_with_readiness(
             control.wait_while_paused();
         }
         pump_v8_message_loop(scope);
+        if crate::isolate::process_exit_code(scope).is_some() {
+            return EventLoopStatus::Terminated;
+        }
 
         // Bound completion work per turn so a response flood cannot starve
         // ordinary stream/control events.
@@ -3302,6 +3346,9 @@ fn run_event_loop_with_readiness(
         // a fixed empty-work floor to every readiness and bridge completion.
         scope.perform_microtask_checkpoint();
         pump_v8_message_loop(scope);
+        if crate::isolate::process_exit_code(scope).is_some() {
+            return EventLoopStatus::Terminated;
+        }
 
         if pending_guest_immediate_count(scope) > 0 {
             match try_recv_session_command(scope, rx, ready_rx, ready_broker, bridge_rx, abort_rx) {

--- a/examples/command-code/README.md
+++ b/examples/command-code/README.md
@@ -1,0 +1,23 @@
+---
+title: "Command Code CLI"
+description: "Run the Command Code v1 CLI directly in an agentOS VM."
+category: "Agents"
+order: 5
+---
+
+# Command Code CLI
+
+Run the genuine Command Code v1 CLI inside an agentOS VM. This example invokes `cmd` directly in headless mode; it does not use an ACP adapter.
+
+## Run it
+
+```bash
+pnpm install
+export COMMAND_CODE_API_KEY=...
+pnpm tsx server.ts   # starts the registry on http://localhost:6420
+pnpm tsx client.ts   # runs cmd -p and prints its JSON output
+```
+
+## Source
+
+View the source on GitHub: https://github.com/rivet-dev/agentos/tree/main/examples/command-code

--- a/examples/command-code/client.ts
+++ b/examples/command-code/client.ts
@@ -1,0 +1,32 @@
+// docs:start quickstart
+import { createClient } from "@rivet-dev/agentos/client";
+import type { registry } from "./server";
+
+const client = createClient<typeof registry>({
+	endpoint: "http://localhost:6420",
+});
+const agent = client.vm.getOrCreate("my-agent");
+const apiKey = process.env.COMMAND_CODE_API_KEY;
+if (!apiKey) throw new Error("COMMAND_CODE_API_KEY is required");
+
+await agent.mkdir("/workspace", { recursive: true });
+const result = await agent.execArgv(
+	"cmd",
+	[
+		"-p",
+		"What files are in the current directory?",
+		"--output-format",
+		"json",
+		"--trust",
+		"--yolo",
+		"--skip-onboarding",
+		"--no-auto-update",
+	],
+	{
+		cwd: "/workspace",
+		env: { COMMAND_CODE_API_KEY: apiKey },
+	},
+);
+if (result.exitCode !== 0) throw new Error(result.stderr || result.stdout);
+console.log(result.stdout);
+// docs:end quickstart

--- a/examples/command-code/package.json
+++ b/examples/command-code/package.json
@@ -1,0 +1,19 @@
+{
+	"name": "@rivet-dev/agentos-example-command-code",
+	"version": "0.0.1",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"check-types": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@agentos-software/command-code": "workspace:*",
+		"@rivet-dev/agentos": "workspace:*",
+		"rivetkit": "catalog:rivetkit"
+	},
+	"devDependencies": {
+		"@types/node": "^22.10.2",
+		"tsx": "^4.19.0",
+		"typescript": "^5.7.2"
+	}
+}

--- a/examples/command-code/server.ts
+++ b/examples/command-code/server.ts
@@ -1,0 +1,7 @@
+import commandCode from "@agentos-software/command-code";
+import { agentOS, setup } from "@rivet-dev/agentos";
+
+const vm = agentOS({ software: [commandCode] });
+
+export const registry = setup({ use: { vm } });
+registry.start();

--- a/examples/command-code/tsconfig.json
+++ b/examples/command-code/tsconfig.json
@@ -1,0 +1,15 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"moduleResolution": "bundler",
+		"noEmit": true,
+		"lib": ["ESNext", "DOM"],
+		"types": ["node"],
+		"baseUrl": ".",
+		"paths": {
+			"@rivet-dev/agentos": ["../../packages/agentos/src/index.ts"],
+			"@rivet-dev/agentos/client": ["../../packages/agentos/src/client.ts"]
+		}
+	},
+	"include": ["**/*.ts"]
+}

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
 	"devDependencies": {
 		"@agentos-software/claude-code": "workspace:*",
 		"@agentos-software/codex": "workspace:*",
+		"@agentos-software/command-code": "workspace:*",
 		"@agentos-software/common": "workspace:*",
 		"@agentos-software/opencode": "workspace:*",
 		"@agentos-software/pi": "workspace:*",

--- a/packages/build-tools/bridge-src/builtins/console.ts
+++ b/packages/build-tools/bridge-src/builtins/console.ts
@@ -211,6 +211,9 @@ function formatConsoleValue(value) {
 }
 
 function formatConsoleArgs(args) {
+  if (args.length === 0) {
+    return "";
+  }
   const builtinUtilModule = installBuiltinUtilFormatWithOptions(
     globalThis.__secureExecBuiltinUtilModule
   );

--- a/packages/build-tools/bridge-src/builtins/process.ts
+++ b/packages/build-tools/bridge-src/builtins/process.ts
@@ -645,6 +645,10 @@ var process2 = {
       _emit("exit", exitCode);
     } catch (_e) {
     }
+    if (typeof globalThis.__secureExecProcessExit === "function") {
+      globalThis.__secureExecProcessExit(exitCode);
+      return;
+    }
     throw new ProcessExitError(exitCode);
   },
   abort() {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -80,6 +80,7 @@
 	"devDependencies": {
 		"@agentos-software/claude-code": "workspace:*",
 		"@agentos-software/codex": "workspace:*",
+		"@agentos-software/command-code": "workspace:*",
 		"@agentos-software/coreutils": "workspace:*",
 		"@agentos-software/curl": "workspace:*",
 		"@agentos-software/diffutils": "workspace:*",

--- a/packages/core/tests/command-code-package-projection.test.ts
+++ b/packages/core/tests/command-code-package-projection.test.ts
@@ -87,6 +87,31 @@ describe("Command Code package projection", () => {
 		expect(skills.exitCode, skills.stderr).toBe(0);
 		expect(skills.stdout).toContain("demo");
 
+		const localMod = `${workspace}/local-mod`;
+		await vm.mkdir(`${localMod}/mods`, { recursive: true });
+		await vm.writeFile(
+			`${localMod}/package.json`,
+			`${JSON.stringify({
+				name: "agentos-local-mod",
+				version: "1.0.0",
+				commandcode: { mods: ["./mods/hello.ts"] },
+			})}\n`,
+		);
+		await vm.writeFile(
+			`${localMod}/mods/hello.ts`,
+			'export default function (cmd) { cmd.addCommand({ name: "agentos-hello", handler: () => ({ message: "hello" }) }); }\n',
+		);
+		const modAdd = await vm.execArgv(
+			"cmd",
+			["mods", "add", "-g", "./local-mod"],
+			options,
+		);
+		expect(modAdd.exitCode, modAdd.stderr).toBe(0);
+		const modList = await vm.execArgv("cmd", ["mods", "list"], options);
+		expect(modList.exitCode, modList.stderr).toBe(0);
+		expect(modList.stdout).toContain("hello · package");
+		expect(modList.stdout).toContain(`local:${localMod} · user · installed`);
+
 		const mcpAdd = await vm.execArgv(
 			"cmd",
 			[
@@ -182,5 +207,34 @@ describe("Command Code package projection", () => {
 			}
 		},
 		120_000,
+	);
+
+	test.runIf(process.env.AGENTOS_RUN_COMMAND_CODE_NETWORK_TEST === "1")(
+		"installs an npm mod package",
+		async () => {
+			await vm?.dispose();
+			vm = await AgentOs.create({ software: [commandCode] });
+			const home = "/home/agentos-command-code-network";
+			const workspace = `${home}/workspace`;
+			await vm.mkdir(workspace, { recursive: true });
+			const options = {
+				cwd: workspace,
+				env: {
+					COMMANDCODE_SKIP_UPDATES: "1",
+					DO_NOT_TRACK: "1",
+					HOME: home,
+				},
+			};
+			const add = await vm.execArgv(
+				"cmd",
+				["mods", "add", "-g", "npm:cmd-mod-hi@0.1.1"],
+				options,
+			);
+			expect(add.exitCode, add.stderr).toBe(0);
+			const list = await vm.execArgv("cmd", ["mods", "list"], options);
+			expect(list.exitCode, list.stderr).toBe(0);
+			expect(list.stdout).toContain("npm:cmd-mod-hi · user · installed");
+		},
+		180_000,
 	);
 });

--- a/packages/core/tests/command-code-package-projection.test.ts
+++ b/packages/core/tests/command-code-package-projection.test.ts
@@ -1,0 +1,186 @@
+import commandCode from "@agentos-software/command-code";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { AgentOs } from "../src/agent-os.js";
+
+describe("Command Code package projection", () => {
+	let vm: AgentOs | undefined;
+
+	beforeEach(async () => {
+		vm = await AgentOs.create({
+			defaultSoftware: false,
+			software: [commandCode],
+		});
+	}, 120_000);
+
+	afterEach(async () => {
+		await vm?.dispose();
+	});
+
+	test("projects the genuine v1 CLI without registering an ACP agent", async () => {
+		if (!vm) throw new Error("VM setup failed");
+		for (const command of ["cmd", "cmdc", "command-code", "commandcode"]) {
+			expect(await vm.exists(`/opt/agentos/bin/${command}`)).toBe(true);
+		}
+		expect(await vm.exists("/opt/agentos/bin/command-code-acp")).toBe(false);
+		expect(await vm.listAgents()).not.toEqual(
+			expect.arrayContaining([expect.objectContaining({ id: "command-code" })]),
+		);
+
+		const version = await vm.execArgv("cmd", ["--version"]);
+		expect(version.exitCode, version.stderr).toBe(0);
+		expect(version.stdout.trim()).toBe("1.1.0");
+
+		const help = await vm.execArgv("cmd", ["--help"]);
+		expect(help.exitCode, help.stderr).toBe(0);
+		expect(help.stdout).toContain("Command Code v1.1.0");
+		expect(help.stdout).toContain("--output-format <format>");
+		expect(help.stdout).toContain("mcp");
+		expect(help.stdout).toContain("skills");
+		expect(help.stdout).not.toMatch(/(^|\n)undefined(\n|$)/);
+
+		const processExit = await vm.execArgv("node", [
+			"-e",
+			"try { process.exit(23) } catch { console.log('caught') } finally { console.log('finally') }",
+		]);
+		expect(processExit.exitCode).toBe(23);
+		expect(processExit.stdout).toBe("");
+
+		const asyncProcessExit = await vm.execArgv("node", [
+			"-e",
+			"setTimeout(() => process.exit(24), 0); setTimeout(() => console.log('late'), 1000)",
+		]);
+		expect(asyncProcessExit.exitCode, asyncProcessExit.stderr).toBe(24);
+		expect(asyncProcessExit.stdout).toBe("");
+	}, 120_000);
+
+	test("runs status, skills, MCP configuration, and headless auth handling", async () => {
+		if (!vm) throw new Error("VM setup failed");
+		const home = "/home/agentos-command-code";
+		const workspace = `${home}/workspace`;
+		await vm.mkdir(workspace, { recursive: true });
+		await vm.mkdir(`${workspace}/.agents/skills/demo`, { recursive: true });
+		await vm.writeFile(
+			`${workspace}/.agents/skills/demo/SKILL.md`,
+			"---\nname: demo\ndescription: Test skill discovery.\n---\n\n# Demo\n",
+		);
+		const options = {
+			cwd: workspace,
+			env: {
+				COMMANDCODE_SKIP_UPDATES: "1",
+				DO_NOT_TRACK: "1",
+				HOME: home,
+			},
+		};
+
+		const status = await vm.execArgv("cmd", ["status", "--json"], options);
+		expect(status.exitCode, status.stderr).toBe(1);
+		expect(JSON.parse(status.stdout)).toMatchObject({
+			authenticated: false,
+			version: "1.1.0",
+		});
+
+		const skills = await vm.execArgv(
+			"cmd",
+			["skills", "list", "--debug"],
+			options,
+		);
+		expect(skills.exitCode, skills.stderr).toBe(0);
+		expect(skills.stdout).toContain("demo");
+
+		const mcpAdd = await vm.execArgv(
+			"cmd",
+			[
+				"mcp",
+				"add",
+				"--transport",
+				"http",
+				"--scope",
+				"project",
+				"demo",
+				"https://example.com/mcp",
+			],
+			options,
+		);
+		expect(mcpAdd.exitCode, mcpAdd.stderr).toBe(0);
+		const mcpGet = await vm.execArgv("cmd", ["mcp", "get", "demo"], options);
+		expect(mcpGet.exitCode, mcpGet.stderr).toBe(0);
+		expect(mcpGet.stdout).toContain("https://example.com/mcp");
+		expect(
+			JSON.parse(
+				new TextDecoder().decode(await vm.readFile(`${workspace}/.mcp.json`)),
+			),
+		).toMatchObject({
+			mcpServers: {
+				demo: {
+					transport: "http",
+					url: "https://example.com/mcp",
+				},
+			},
+		});
+
+		const headless = await vm.execArgv(
+			"cmd",
+			[
+				"-p",
+				"hello",
+				"--output-format",
+				"json",
+				"--trust",
+				"--skip-onboarding",
+				"--no-auto-update",
+			],
+			options,
+		);
+		expect(headless.exitCode, headless.stderr).toBe(3);
+		expect(headless.stdout).toContain("Not authenticated");
+	}, 120_000);
+
+	test.runIf(process.env.AGENTOS_RUN_COMMAND_CODE_AUTH_TEST === "1")(
+		"authenticates an API key and reaches the hosted model boundary",
+		async () => {
+			if (!vm) throw new Error("VM setup failed");
+			const apiKey = process.env.COMMAND_CODE_API_KEY;
+			if (!apiKey) throw new Error("COMMAND_CODE_API_KEY is required");
+			const home = "/home/agentos-command-code-authenticated";
+			const workspace = `${home}/workspace`;
+			await vm.mkdir(workspace, { recursive: true });
+			const options = {
+				cwd: workspace,
+				env: {
+					COMMAND_CODE_API_KEY: apiKey,
+					COMMANDCODE_SKIP_UPDATES: "1",
+					DO_NOT_TRACK: "1",
+					HOME: home,
+				},
+			};
+			const status = await vm.execArgv("cmd", ["status", "--json"], options);
+			expect(status.exitCode, status.stderr).toBe(0);
+			expect(JSON.parse(status.stdout)).toMatchObject({ authenticated: true });
+
+			const result = await vm.execArgv(
+				"cmd",
+				[
+					"-p",
+					"Reply with exactly COMMAND_CODE_AUTH_OK and no other text. Do not use tools.",
+					"--output-format",
+					"json",
+					"--trust",
+					"--skip-onboarding",
+					"--no-auto-update",
+					"--max-turns",
+					"1",
+				],
+				options,
+			);
+			if (result.exitCode === 0) {
+				expect(result.stdout).toContain("COMMAND_CODE_AUTH_OK");
+			} else {
+				expect(result.exitCode).toBe(10);
+				expect(result.stderr || result.stdout).toContain(
+					"insufficient credits",
+				);
+			}
+		},
+		120_000,
+	);
+});

--- a/packages/runtime-core/tests/integration/node-binary-behavior.nightly.test.ts
+++ b/packages/runtime-core/tests/integration/node-binary-behavior.nightly.test.ts
@@ -145,6 +145,26 @@ describeIf(!skipReason, 'node binary: exec exit codes', () => {
     const result = await ctx.kernel.exec('node -e "process.exit(0)"');
     expect(result.exitCode).toBe(0);
   });
+
+  it('process.exit is not catchable and skips finally blocks', async () => {
+    ctx = await createIntegrationKernel({ runtimes: ['wasmvm', 'node'] });
+    const result = await ctx.kernel.execArgv('node', [
+      '-e',
+      "try { process.exit(23) } catch { console.log('caught') } finally { console.log('finally') }",
+    ]);
+    expect(result.exitCode).toBe(23);
+    expect(result.stdout).toBe('');
+  });
+
+  it('process.exit from an async callback terminates active handles', async () => {
+    ctx = await createIntegrationKernel({ runtimes: ['wasmvm', 'node'] });
+    const result = await ctx.kernel.execArgv('node', [
+      '-e',
+      "setTimeout(() => process.exit(24), 0); setTimeout(() => console.log('late'), 1000)",
+    ]);
+    expect(result.exitCode).toBe(24);
+    expect(result.stdout).toBe('');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@agentos-software/codex':
         specifier: workspace:*
         version: link:software/codex
+      '@agentos-software/command-code':
+        specifier: workspace:*
+        version: link:software/command-code
       '@agentos-software/common':
         specifier: workspace:*
         version: link:software/common
@@ -115,7 +118,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -143,7 +146,7 @@ importers:
         version: link:../../packages/agentos
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
     devDependencies:
       '@types/node':
         specifier: ^22.10.2
@@ -183,7 +186,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -232,7 +235,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -281,7 +284,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -324,7 +327,7 @@ importers:
         version: link:../../packages/agentos
       '@rivetkit/react':
         specifier: catalog:rivetkit
-        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)(pyodide@0.28.3(bufferutil@4.1.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(ws@8.21.0(bufferutil@4.1.0))
       '@xterm/addon-fit':
         specifier: ^0.10.0
         version: 0.10.0(@xterm/xterm@5.5.0)
@@ -339,7 +342,7 @@ importers:
         version: 19.2.7(react@19.2.7)
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
     devDependencies:
       '@types/react':
         specifier: ^19.0.0
@@ -379,7 +382,7 @@ importers:
         version: link:../../packages/agentos
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
     devDependencies:
       '@types/node':
         specifier: ^22.10.2
@@ -422,7 +425,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -471,13 +474,35 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
       zod:
         specifier: ^4.1.11
         version: 4.3.6
+    devDependencies:
+      '@types/node':
+        specifier: ^22.10.2
+        version: 22.19.15
+      tsx:
+        specifier: ^4.19.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.7.2
+        version: 5.9.3
+
+  examples/command-code:
+    dependencies:
+      '@agentos-software/command-code':
+        specifier: workspace:*
+        version: link:../../software/command-code
+      '@rivet-dev/agentos':
+        specifier: workspace:*
+        version: link:../../packages/agentos
+      rivetkit:
+        specifier: catalog:rivetkit
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
     devDependencies:
       '@types/node':
         specifier: ^22.10.2
@@ -520,7 +545,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -569,7 +594,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -618,7 +643,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -667,7 +692,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -716,7 +741,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -765,7 +790,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -814,7 +839,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -863,7 +888,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -912,7 +937,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -961,7 +986,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1010,7 +1035,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1059,7 +1084,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1108,7 +1133,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1157,7 +1182,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1206,7 +1231,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1255,7 +1280,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1310,7 +1335,7 @@ importers:
         version: 18.3.1(react@18.3.1)
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1362,7 +1387,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1411,7 +1436,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1479,7 +1504,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1528,7 +1553,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1577,7 +1602,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1626,7 +1651,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1675,7 +1700,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1724,7 +1749,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1773,7 +1798,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1822,7 +1847,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1871,7 +1896,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1920,7 +1945,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1969,7 +1994,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -2018,7 +2043,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -2067,7 +2092,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -2125,7 +2150,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -2156,16 +2181,16 @@ importers:
         version: link:../../packages/eve
       '@rivet-dev/vercel-world':
         specifier: 2.3.7
-        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)(ws@8.21.0(bufferutil@4.1.0))
       '@vercel/connect':
         specifier: 0.4.0
-        version: 0.4.0(ai@7.0.26(zod@4.3.6))(eve@0.27.0(@opentelemetry/api@1.9.0)(ai@7.0.26(zod@4.3.6))(aws4fetch@1.0.20)(better-sqlite3@12.8.0)(chokidar@5.0.0)(dotenv@16.6.1)(drizzle-orm@0.44.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0))(jiti@2.7.0)(lru-cache@11.2.7))
+        version: 0.4.0(ai@7.0.26(zod@4.3.6))(eve@0.27.0(@opentelemetry/api@1.9.0)(ai@7.0.26(zod@4.3.6))(aws4fetch@1.0.20)(better-sqlite3@12.8.0)(chokidar@5.0.0)(dotenv@17.4.2)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9))(giget@3.3.0)(jiti@2.7.0)(lru-cache@11.2.7))
       ai:
         specifier: 7.0.26
         version: 7.0.26(zod@4.3.6)
       eve:
         specifier: 0.27.0
-        version: 0.27.0(@opentelemetry/api@1.9.0)(ai@7.0.26(zod@4.3.6))(aws4fetch@1.0.20)(better-sqlite3@12.8.0)(chokidar@5.0.0)(dotenv@16.6.1)(drizzle-orm@0.44.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0))(jiti@2.7.0)(lru-cache@11.2.7)
+        version: 0.27.0(@opentelemetry/api@1.9.0)(ai@7.0.26(zod@4.3.6))(aws4fetch@1.0.20)(better-sqlite3@12.8.0)(chokidar@5.0.0)(dotenv@17.4.2)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9))(giget@3.3.0)(jiti@2.7.0)(lru-cache@11.2.7)
       zod:
         specifier: 4.3.6
         version: 4.3.6
@@ -2211,7 +2236,7 @@ importers:
         version: 4.12.9
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -2260,7 +2285,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -2306,7 +2331,7 @@ importers:
         version: 9.14.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       tsx:
         specifier: ^4.19.0
         version: 4.21.0
@@ -2340,10 +2365,10 @@ importers:
         version: link:../core
       '@rivetkit/react':
         specifier: catalog:rivetkit
-        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)(pyodide@0.28.3(bufferutil@4.1.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(ws@8.21.0(bufferutil@4.1.0))
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       zod:
         specifier: ^4.1.11
         version: 4.3.6
@@ -2583,6 +2608,9 @@ importers:
       '@agentos-software/codex':
         specifier: workspace:*
         version: link:../../software/codex
+      '@agentos-software/command-code':
+        specifier: workspace:*
+        version: link:../../software/command-code
       '@agentos-software/coreutils':
         specifier: workspace:*
         version: link:../../software/coreutils
@@ -2651,7 +2679,7 @@ importers:
         version: 0.15.0(@bare-ts/lib@0.4.0)
       '@browserbasehq/browse-cli':
         specifier: 0.5.0
-        version: 0.5.0(@cfworker/json-schema@4.1.1)(@opentelemetry/api@1.9.0)(bufferutil@4.1.0)(deepmerge@4.3.1)(zod@4.3.6)
+        version: 0.5.0(@cfworker/json-schema@4.1.1)(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(bufferutil@4.1.0)(deepmerge@4.3.1)(zod@4.3.6)
       '@browserbasehq/cli':
         specifier: 0.5.4
         version: 0.5.4
@@ -2699,7 +2727,7 @@ importers:
         version: 7.0.26(zod@4.3.6)
       eve:
         specifier: 0.27.0
-        version: 0.27.0(@opentelemetry/api@1.9.0)(ai@7.0.26(zod@4.3.6))(aws4fetch@1.0.20)(better-sqlite3@12.8.0)(chokidar@5.0.0)(dotenv@16.6.1)(drizzle-orm@0.44.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0))(jiti@2.7.0)(lru-cache@11.2.7)
+        version: 0.27.0(@opentelemetry/api@1.9.0)(ai@7.0.26(zod@4.3.6))(aws4fetch@1.0.20)(better-sqlite3@12.8.0)(chokidar@5.0.0)(dotenv@17.4.2)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9))(giget@3.3.0)(jiti@2.7.0)(lru-cache@11.2.7)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -2996,7 +3024,7 @@ importers:
         version: 14.0.3
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
     devDependencies:
       '@types/node':
         specifier: ^22.19.3
@@ -3241,6 +3269,31 @@ importers:
       vitest:
         specifier: ^2.1.9
         version: 2.1.9(@types/node@22.19.15)
+
+  software/command-code:
+    dependencies:
+      '@crosscopy/clipboard':
+        specifier: 0.2.8
+        version: 0.2.8
+    devDependencies:
+      '@agentos-software/manifest':
+        specifier: workspace:*
+        version: link:../../packages/manifest
+      '@rivet-dev/agentos-toolchain':
+        specifier: workspace:*
+        version: link:../../packages/agentos-toolchain
+      '@types/node':
+        specifier: ^22.10.2
+        version: 22.19.15
+      command-code:
+        specifier: 1.1.0
+        version: 1.1.0(@types/react@19.2.17)(better-sqlite3@12.8.0)(bufferutil@4.1.0)
+      esbuild:
+        specifier: 0.27.4
+        version: 0.27.4
+      typescript:
+        specifier: ^5.7.2
+        version: 5.9.3
 
   software/common:
     dependencies:
@@ -4017,7 +4070,7 @@ importers:
         version: 3.7.3
       '@astrojs/tailwind':
         specifier: ^6.0.0
-        version: 6.0.2(astro@5.18.2(@types/node@24.13.2)(aws4fetch@1.0.20)(db0@0.3.4(better-sqlite3@12.8.0)(drizzle-orm@0.44.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)))(jiti@2.7.0)(rollup@4.60.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.9.0))
+        version: 6.0.2(astro@5.18.2(@types/node@24.13.2)(aws4fetch@1.0.20)(db0@0.3.4(better-sqlite3@12.8.0)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)))(jiti@2.7.0)(rollup@4.60.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.9.0))
       '@rivet-dev/docs-theme':
         specifier: workspace:*
         version: link:vendor/theme
@@ -4029,7 +4082,7 @@ importers:
         version: link:vendor/theme/vendor/icons
       astro:
         specifier: ^5.18.2
-        version: 5.18.2(@types/node@24.13.2)(aws4fetch@1.0.20)(db0@0.3.4(better-sqlite3@12.8.0)(drizzle-orm@0.44.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)))(jiti@2.7.0)(rollup@4.60.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0)
+        version: 5.18.2(@types/node@24.13.2)(aws4fetch@1.0.20)(db0@0.3.4(better-sqlite3@12.8.0)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)))(jiti@2.7.0)(rollup@4.60.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0)
       framer-motion:
         specifier: ^12.0.0
         version: 12.42.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -4076,7 +4129,7 @@ importers:
     dependencies:
       '@astrojs/mdx':
         specifier: ^4.0.2
-        version: 4.3.14(astro@5.18.2(@types/node@24.13.2)(aws4fetch@1.0.20)(db0@0.3.4(better-sqlite3@12.8.0)(drizzle-orm@0.44.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)))(jiti@2.7.0)(rollup@4.60.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0))
+        version: 4.3.14(astro@5.18.2(@types/node@24.13.2)(aws4fetch@1.0.20)(db0@0.3.4(better-sqlite3@12.8.0)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)))(jiti@2.7.0)(rollup@4.60.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0))
       '@astrojs/react':
         specifier: ^4.1.2
         version: 4.4.2(@types/node@24.13.2)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tsx@4.21.0)(yaml@2.9.0)
@@ -4118,7 +4171,7 @@ importers:
         version: 8.17.0
       astro:
         specifier: '>=5.0.0'
-        version: 5.18.2(@types/node@24.13.2)(aws4fetch@1.0.20)(db0@0.3.4(better-sqlite3@12.8.0)(drizzle-orm@0.44.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)))(jiti@2.7.0)(rollup@4.60.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0)
+        version: 5.18.2(@types/node@24.13.2)(aws4fetch@1.0.20)(db0@0.3.4(better-sqlite3@12.8.0)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)))(jiti@2.7.0)(rollup@4.60.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -4529,6 +4582,12 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/anthropic@3.0.100':
+    resolution: {integrity: sha512-/o2a3zVPdwRGSHYgssZ6Xec0vdhlgzMpm/T6JmifApVc5j6JmMChtV+sZ3omUqCFmHxfPzHvvNumplDFh3zrmw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/anthropic@3.0.64':
     resolution: {integrity: sha512-rwLi/Rsuj2pYniQXIrvClHvXDzgM4UQHHnvHTWEF14efnlKclG/1ghpNC+adsRujAbCTr6gRsSbDE2vEqriV7g==}
     engines: {node: '>=18'}
@@ -4613,6 +4672,12 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/openai-compatible@2.0.62':
+    resolution: {integrity: sha512-lRe54zvyIS1a60N8UVhnwKZRI5I+GSV8uhKkPpId+aiKO7z7UgSbNqFmXkBBMD3yc9UrLnQnATV2EQyXNhzEkA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/openai@2.0.102':
     resolution: {integrity: sha512-tYarHJhyMioGegsnhpqz1/tKoCAJJ6zBHoIQaredNkt8V3o/JXj2647NnEOJVe7WHQXGvCfzbfnP1TADFhPmcA==}
     engines: {node: '>=18'}
@@ -4621,6 +4686,12 @@ packages:
 
   '@ai-sdk/openai@2.0.110':
     resolution: {integrity: sha512-PVbq0vXo6LVBCKeIOiDsOfrUIL2IOkMUipWP53SJZppDo594kbu5BFs/NdwnJMAX4q6EM6sGPVv751RN9PrZ9A==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/openai@3.0.87':
+    resolution: {integrity: sha512-fg0Lyr99bX2ApS0+cgKlndOK3l53nNF6JtlQcPsMVp0/tgzAMZSXQ+H5GAy0pdJjevmmwMY5rQaq3L6wE+cSvA==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -4649,6 +4720,12 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/provider-utils@4.0.40':
+    resolution: {integrity: sha512-OL5IrpUm9Y8Dwy+w/vvFwPotS6m52O9W0op2oXgXdCROMJIBalBI0oro6OIBYkPxvm5Xg02GSkoQN25RlR0bnw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/provider-utils@5.0.9':
     resolution: {integrity: sha512-BohlmQ62x+iIOawYCS2z5JzokMq5kZSoVhJawH41mlMdkb01xqhIMG8L0NAByneUFLpdUlSjJjF/bel5j3cGZA==}
     engines: {node: '>=22'}
@@ -4661,6 +4738,10 @@ packages:
 
   '@ai-sdk/provider@2.0.3':
     resolution: {integrity: sha512-h88OPkavHTiN9tMn2l5awAznGB0lXzjcLhgR1/rvjB2zlLprsNxbM2tt6OJsHUxduLC3klq0/eqaSf6fX5XVww==}
+    engines: {node: '>=18'}
+
+  '@ai-sdk/provider@3.0.14':
+    resolution: {integrity: sha512-5X1k57JBJ4H7H1QjX7CnJYAB1I19r/trVZTMcSms7/kLNZ8RaU4Nt2agcwZzv82Hfx6Q7/TOLU7agAKeFfc8cA==}
     engines: {node: '>=18'}
 
   '@ai-sdk/provider@3.0.8':
@@ -4682,6 +4763,10 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
+
+  '@alcalzone/ansi-tokenize@0.3.0':
+    resolution: {integrity: sha512-p+CMKJ93HFmLkjXKlXiVGlMQEuRb6H0MokBSwUsX+S6BRX8eV5naFZpQJFfJHjRZY0Hmnqy1/r6UWl3x+19zYA==}
+    engines: {node: '>=18'}
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -5309,6 +5394,14 @@ packages:
   '@chevrotain/types@11.1.2':
     resolution: {integrity: sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==}
 
+  '@clack/core@1.4.3':
+    resolution: {integrity: sha512-/kr3UWNtdJfxZtPgDqUOmG2pvwlmcLGheex5yiZKdwbzZJxhV+HMNR9QNmyY5cGwTNV6LrR7Jtp+KjhUAP1qBQ==}
+    engines: {node: '>= 20.12.0'}
+
+  '@clack/prompts@1.7.0':
+    resolution: {integrity: sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A==}
+    engines: {node: '>= 20.12.0'}
+
   '@codemirror/autocomplete@6.20.3':
     resolution: {integrity: sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g==}
 
@@ -5339,11 +5432,66 @@ packages:
   '@codemirror/view@6.43.6':
     resolution: {integrity: sha512-EVunGSYN1wz1p75WY1s3Xg7t3i8Yol0kGZGizNdX9BUFgMFILYVe8/u6EVpo7Ff5PwbZuILb4QAq7IZoKzIEQA==}
 
+  '@colors/colors@1.5.0':
+    resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
+    engines: {node: '>=0.1.90'}
+
   '@copilotkit/llmock@1.6.0':
     resolution: {integrity: sha512-wq4J7ampjoEiOi6v2d7GMK5lTZcTnuhMduSPCIwmyxBTCPA3lekXyNKGJ4t3xM5OgoJReMQ5KmlfrMBVTRNGsA==}
     engines: {node: '>=20.15.0'}
     deprecated: This package has moved to @copilotkit/aimock
     hasBin: true
+
+  '@crosscopy/clipboard-darwin-arm64@0.2.8':
+    resolution: {integrity: sha512-Y36ST9k5JZgtDE6SBT45bDNkPKBHd4UEIZgWnC0iC4kAWwdjPmsZ8Mn8e5W0YUKowJ/BDcO+EGm2tVTPQOQKXg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@crosscopy/clipboard-darwin-universal@0.2.8':
+    resolution: {integrity: sha512-btGV1tLpJWZ4iKa66niahvpZpVRJzgQnYUE+PUX3YYZzaWD0ESuHuVtKVC8sR+b4dsXIiWW5skXbcRmLsF4rtA==}
+    engines: {node: '>= 10'}
+    os: [darwin]
+
+  '@crosscopy/clipboard-darwin-x64@0.2.8':
+    resolution: {integrity: sha512-0QMKf0XrLZrprYYXU4lgaTuzbnYPh9wH6PvsfDB1FZvWf6rOi0syTaBZYnoghbQe700qwLPEfBRjgljJ3Tn6oA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@crosscopy/clipboard-linux-arm64-gnu@0.2.8':
+    resolution: {integrity: sha512-8YrU03MRsygymqEcHkNgqCqSCQbYRmJCnMXeS4i8FYeOkAxBEeRvPbHoNmI10uppXJZNZgfIKM7Qqk9tEHiwqQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@crosscopy/clipboard-linux-riscv64-gnu@0.2.8':
+    resolution: {integrity: sha512-/QWLhnb0QYVjEv5GOAC1q+1DaezYU8Th+IoDKUCsR5i43Cqm+g+N/I2K35yo3J+HHkK9XNbtIDZDXlFgK6tRUg==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@crosscopy/clipboard-linux-x64-gnu@0.2.8':
+    resolution: {integrity: sha512-j17eaF/onP/6VAGGKtxA1KmmkErmdjta9gMdMV/yUmgeBYzJ9fMpWUzbk2vmaOyXfhaSzR/sk1P6VLBmvCpqHg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@crosscopy/clipboard-win32-arm64-msvc@0.2.8':
+    resolution: {integrity: sha512-MVkMyuYN3y5v0s4HrijM0iA8hZVmpUhHd8X4zKG30t4nE6MbOjOt/8EabMrVmGZlsLeOL2sa0o8Wo9bvhWU+vA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@crosscopy/clipboard-win32-x64-msvc@0.2.8':
+    resolution: {integrity: sha512-/GpiB4B3lSgg7eCLDQw9NfFjtQFjo0S88IL+EK54Hx7ZgAP4Ad/ezP/8dw0cA+N/M6iPYy0reCIjW9st82/uxw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@crosscopy/clipboard@0.2.8':
+    resolution: {integrity: sha512-0qRWscafAHzQ+DdfXX+YgPN2KDTIzWBNfN5Q6z1CgCWsRxtkwK8HfQUc00xIejfRWSGWPIxcCTg82hvg06bodg==}
+    engines: {node: '>= 10'}
 
   '@earendil-works/pi-agent-core@0.80.10':
     resolution: {integrity: sha512-nwnOR3SuLYGRFfyQm8ri4Nj5VGVAvAM9GuqQd3u7BUQj0d6hmD2F8w7OHAAjThE3CuySIdM+v8E22QJG6/RfCg==}
@@ -6229,6 +6377,118 @@ packages:
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
 
+  '@jimp/core@1.6.1':
+    resolution: {integrity: sha512-+BoKC5G6hkrSy501zcJ2EpfnllP+avPevcBfRcZe/CW+EwEfY6X1EZ8QWyT7NpDIvEEJb1fdJnMMfUnFkxmw9A==}
+    engines: {node: '>=18'}
+
+  '@jimp/diff@1.6.1':
+    resolution: {integrity: sha512-YkKDPdHjLgo1Api3+Bhc0GLAygldlpt97NfOKoNg1U6IUNXA6X2MgosCjPfSBiSvJvrrz1fsIR+/4cfYXBI/HQ==}
+    engines: {node: '>=18'}
+
+  '@jimp/file-ops@1.6.1':
+    resolution: {integrity: sha512-T+gX6osHjprbDRad0/B71Evyre7ZdVY1z/gFGEG9Z8KOtZPKboWvPeP2UjbZYWQLy9UKCPQX1FNAnDiOPkJL7w==}
+    engines: {node: '>=18'}
+
+  '@jimp/js-bmp@1.6.1':
+    resolution: {integrity: sha512-xzWzNT4/u5zGrTT3Tme9sGU7YzIKxi13+BCQwLqACbt5DXf9SAfdzRkopZQnmDko+6In5nqaT89Gjs43/WdnYQ==}
+    engines: {node: '>=18'}
+
+  '@jimp/js-gif@1.6.1':
+    resolution: {integrity: sha512-YjY2W26rQa05XhanYhRZ7dingCiNN+T2Ymb1JiigIbABY0B28wHE3v3Cf1/HZPWGu0hOg36ylaKgV5KxF2M58w==}
+    engines: {node: '>=18'}
+
+  '@jimp/js-jpeg@1.6.1':
+    resolution: {integrity: sha512-HT9H3yOmlOFzYmdI15IYdfy6ggQhSRIaHeA+OTJSEORXBqEo97sUZu/DsgHIcX5NJ7TkJBTgZ9BZXsV6UbsyMg==}
+    engines: {node: '>=18'}
+
+  '@jimp/js-png@1.6.1':
+    resolution: {integrity: sha512-SZ/KVhI5UjcSzzlXsXdIi/LhJ7UShf2NkMOtVrbZQcGzsqNtynAelrOXeoTxcanfVqmNhAoVHg8yR2cYoqrYjA==}
+    engines: {node: '>=18'}
+
+  '@jimp/js-tiff@1.6.1':
+    resolution: {integrity: sha512-jDG/eJquID1M4MBlKMmDRBmz2TpXMv7TUyu2nIRUxhlUc2ogC82T+VQUkca9GJH1BBJ9dx5sSE5dGkWNjIbZxw==}
+    engines: {node: '>=18'}
+
+  '@jimp/plugin-blit@1.6.1':
+    resolution: {integrity: sha512-MwnI7C7K81uWddY9FLw1fCOIy6SsPIUftUz36Spt7jisCn8/40DhQMlSxpxTNelnZb/2SnloFimQfRZAmHLOqQ==}
+    engines: {node: '>=18'}
+
+  '@jimp/plugin-blur@1.6.1':
+    resolution: {integrity: sha512-lIo7Tzp5jQu30EFFSK/phXANK3citKVEjepDjQ6ljHoIFtuMRrnybnmI2Md24ulvWlDaz+hh3n6qrMb8ydwhZQ==}
+    engines: {node: '>=18'}
+
+  '@jimp/plugin-circle@1.6.1':
+    resolution: {integrity: sha512-kK1PavY6cKHNNKce37vdV4Tmpc1/zDKngGoeOV3j+EMatoHFZUinV3s6F9aWryPs3A0xhCLZgdJ6Zeea1d5LCQ==}
+    engines: {node: '>=18'}
+
+  '@jimp/plugin-color@1.6.1':
+    resolution: {integrity: sha512-LtUN1vAP+LRlZAtTNVhDRSiXx+26Kbz3zJaG6a5k59gQ95jgT5mknnF8lxkHcqJthM4MEk3/tPxkdJpEybyF/A==}
+    engines: {node: '>=18'}
+
+  '@jimp/plugin-contain@1.6.1':
+    resolution: {integrity: sha512-m0qhrfA8jkTqretGv4w+T/ADFR4GwBpE0sCOC2uJ0dzr44/ddOMsIdrpi89kabqYiPYIrxkgdCVCLm3zn1Vkkg==}
+    engines: {node: '>=18'}
+
+  '@jimp/plugin-cover@1.6.1':
+    resolution: {integrity: sha512-hZytnsth0zoll6cPf434BrT+p/v569Wr5tyO6Dp0dH1IDPhzhB5F38sZGMLDo7bzQiN9JFVB3fxkcJ/WYCJ3Mg==}
+    engines: {node: '>=18'}
+
+  '@jimp/plugin-crop@1.6.1':
+    resolution: {integrity: sha512-EerRSLlclXyKDnYc/H9w/1amZW7b7v3OGi/VlerPd2M/pAu5X8TkyYWtfqYCXnNp1Ixtd8oCo9zGfY9zoXT4rg==}
+    engines: {node: '>=18'}
+
+  '@jimp/plugin-displace@1.6.1':
+    resolution: {integrity: sha512-K07QVl7xQwIfD6KfxRV/c3E9e7ZBXxUXdWuvoTWcKHL2qV48MOF5Nqbz/aJW4ThnQARIsxvYlZjPFiqkCjlU+g==}
+    engines: {node: '>=18'}
+
+  '@jimp/plugin-dither@1.6.1':
+    resolution: {integrity: sha512-+2V+GCV2WycMoX1/z977TkZ8Zq/4MVSKElHYatgUqtwXMi2fDK2gKYU2g9V39IqFvTJsTIsK0+58VFz/ROBVew==}
+    engines: {node: '>=18'}
+
+  '@jimp/plugin-fisheye@1.6.1':
+    resolution: {integrity: sha512-XtS5ZyoZ0vxZxJ6gkqI63SivhtI58vX95foMPM+cyzYkRsJXMOYCr8DScxF5bp4Xr003NjYm/P+7+08tibwzHA==}
+    engines: {node: '>=18'}
+
+  '@jimp/plugin-flip@1.6.1':
+    resolution: {integrity: sha512-ws38W/sGj7LobNRayQ83garxiktOyWxM5vO/y4a/2cy9v65SLEUzVkrj+oeAaUSSObdz4HcCEla7XtGlnAGAaA==}
+    engines: {node: '>=18'}
+
+  '@jimp/plugin-hash@1.6.1':
+    resolution: {integrity: sha512-sZt6ZcMX6i8vFWb4GYnw0pR/o9++ef0dTVcboTB5B/g7nrxCODIB4wfEkJ/YqZM5wUvol77K1qeS0/rVO6z21A==}
+    engines: {node: '>=18'}
+
+  '@jimp/plugin-mask@1.6.1':
+    resolution: {integrity: sha512-SIG0/FcmEj3tkwFxc7fAGLO8o4uNzMpSOdQOhbCgxefQKq5wOVMk9BQx/sdMPBwtMLr9WLq0GzLA/rk6t2v20A==}
+    engines: {node: '>=18'}
+
+  '@jimp/plugin-print@1.6.1':
+    resolution: {integrity: sha512-BYVz/X3Xzv8XYilVeDy11NOp0h7BTDjlOtu0BekIFHP1yHVd24AXNzbOy52XlzYZWQ0Dl36HOHEpl/nSNrzc6w==}
+    engines: {node: '>=18'}
+
+  '@jimp/plugin-quantize@1.6.1':
+    resolution: {integrity: sha512-J2En9PLURfP+vwYDtuZ9T8yBW6BWYZBScydAjRiPBmJfEhTcNQqiiQODrZf7EqbbX/Sy5H6dAeRiqkgoV9N6Ww==}
+    engines: {node: '>=18'}
+
+  '@jimp/plugin-resize@1.6.1':
+    resolution: {integrity: sha512-CLkrtJoIz2HdWnpYiN6p8KYcPc00rCH/SUu6o+lfZL05Q4uhecJlnvXuj9x+U6mDn3ldPmJj6aZqMHuUJzdVqg==}
+    engines: {node: '>=18'}
+
+  '@jimp/plugin-rotate@1.6.1':
+    resolution: {integrity: sha512-nOjVjbbj705B02ksysKnh0POAwEBXZtJ9zQ5qC+X7Tavl3JNn+P3BzQovbBxLPSbUSld6XID9z5ijin4PtOAUg==}
+    engines: {node: '>=18'}
+
+  '@jimp/plugin-threshold@1.6.1':
+    resolution: {integrity: sha512-JOKv9F8s6tnVLf4sB/2fF0F339EFnHvgEdFYugO6VhowKLsap0pEZmLyE/DlRnYtIj2RddHZVxVMp/eKJ04l2Q==}
+    engines: {node: '>=18'}
+
+  '@jimp/types@1.6.1':
+    resolution: {integrity: sha512-leI7YbveTNi565m910XgIOwXyuu074H5qazAD1357HImJSv2hqxnWXpwxQbadGWZ7goZRYBDZy5lpqud0p7q5w==}
+    engines: {node: '>=18'}
+
+  '@jimp/utils@1.6.1':
+    resolution: {integrity: sha512-veFPRd93FCnS7AgmCkPgARVGoDRrJ9cm1ujuNyA+UfQ5VKbED2002sm5XfFLFwTsKC8j04heTrwe+tU1dluXOw==}
+    engines: {node: '>=18'}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -6434,6 +6694,11 @@ packages:
   '@mermaid-js/parser@1.2.0':
     resolution: {integrity: sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==}
 
+  '@microlabs/otel-cf-workers@1.0.0-rc.52':
+    resolution: {integrity: sha512-7jf4sBNoaZCz2RSayefcvc/CZX0PDVA9aVk44bHpUebLrap+xjzDDw4T03klcYrBl/FdC7NamwvqjUMCtYdBvQ==}
+    peerDependencies:
+      '@opentelemetry/api': ~1.9.0
+
   '@microsoft/api-extractor-model@7.28.13':
     resolution: {integrity: sha512-39v/JyldX4MS9uzHcdfmjjfS6cYGAoXV+io8B5a338pkHiSt+gy2eXQ0Q7cGFJ7quSa1VqqlMdlPrB6sLR/cAw==}
 
@@ -6528,9 +6793,257 @@ packages:
   '@opencode-ai/sdk@1.18.3':
     resolution: {integrity: sha512-Mevo4e6kQwbvto9E+42KSIVMhp+JBu+SwQhC5AomAvrV6Xkio3U249T+xDILDCXhl5Z/Hi/DlAuVLzpGnuh0gg==}
 
+  '@opentelemetry/api-logs@0.200.0':
+    resolution: {integrity: sha512-IKJBQxh91qJ+3ssRly5hYEJ8NDHu9oY/B1PXVSCWf7zytmYO9RNLB0Ox9XQ/fJ8m6gY6Q6NtBWlmXfaXt5Uc4Q==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/api-logs@0.218.0':
+    resolution: {integrity: sha512-fmEWp5kXlGEc3i/lR698Hz41DfGyN4Tbe4g7L1AxSc7fF8Xeh/FQ9Quqpa9dVA413Q1Ad43QOLzU4JoXgbFPWw==}
+    engines: {node: '>=8.0.0'}
+
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/configuration@0.218.0':
+    resolution: {integrity: sha512-W8wIz7H2R1pufR5jfjb3gU2XkMpm2x/7b1RJcsuzvd70Il/rWWE+g5/Od7hQKrxRTSrTrOWlru101PWXz5I1EQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+
+  '@opentelemetry/context-async-hooks@2.10.0':
+    resolution: {integrity: sha512-bvyMcgLEkozzSzpEEEo1OMoeQ97bxj6Qs2uN3mPrSdDvObMI1myffD/BPqcLlzZO9//d1SqQA/WPw7Cz2AiqhA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/context-async-hooks@2.7.1':
+    resolution: {integrity: sha512-OPFBYuXEn1E4ja3Y6eeA7O+ZnLBNcXTV5Cgsn1VaqBZ6hC5FnpZPLBNme1LJY8ZtF4aOujPKFoeWN4ik487KuQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/core@2.0.0':
+    resolution: {integrity: sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/core@2.10.0':
+    resolution: {integrity: sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/core@2.7.1':
+    resolution: {integrity: sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/exporter-logs-otlp-grpc@0.218.0':
+    resolution: {integrity: sha512-hoxrNH1l/Xy6F9WTJ5IK+6j1r9nQFlPOmrnTlhYHTySdunfXLmUCPv3bQtKYntxag9h3wLYBZQ2HI6FOx+BT2g==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-logs-otlp-http@0.218.0':
+    resolution: {integrity: sha512-Qx+4rpVHzgg89dawcWRHyt+XRXeLnhFz/qBtvggmjkcgPUdr+NAB0/u/eIPA8yAeJV0J80Vz43JZCh/XFvZFGw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-logs-otlp-proto@0.218.0':
+    resolution: {integrity: sha512-1/noQNsp9gXD75HPzgjBrcF1+XTtry7pFAUfxVEJgg7mPv2AawKQuYkhMmJ8qjxz4Ubc3Y8bwvfxevXsKTq4cg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-metrics-otlp-grpc@0.218.0':
+    resolution: {integrity: sha512-YapQ9vNMX0NSZF6LK5pWAFfjpJleV2O9uYWfYGeb/5F1Kb9rPGK8tZDMJFa/sOksgdFuflDvYuA0B4qjDB4fjQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-metrics-otlp-http@0.218.0':
+    resolution: {integrity: sha512-bV7d2OuMpZu2+gAaxUAhzfZ0h3WVZk8ETQUEE3DNSntbTaMpuITjtm8I0rNyHFdm7Ax57K6ty7SgFXlBmOLIvQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-metrics-otlp-proto@0.218.0':
+    resolution: {integrity: sha512-ubLddKjWULhla9YZRCj/rTBeppjJYE4e9w0icx5mTu3eFhWjQzbV75NYjXuIlEG+NJsBl6d+sTFw5Qu+oej4oQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-prometheus@0.218.0':
+    resolution: {integrity: sha512-RT5oEyu1kddZJ1vt7/BUo5wV+P7hpNAESsR3dUd3+8deHuX7gWNoCOZn+SfDT+hJHlIJ5h/AxiCLXIrutswDJg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-trace-otlp-grpc@0.218.0':
+    resolution: {integrity: sha512-3fXxVQEj9TNAFaCi79JeFKfeLd0sDtInaR3gaZDVlzNSPHtz8PZuCV34JKWjD4XXzT20IdMe8IpX6mRVNDA4Tw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-trace-otlp-http@0.200.0':
+    resolution: {integrity: sha512-Goi//m/7ZHeUedxTGVmEzH19NgqJY+Bzr6zXo1Rni1+hwqaksEyJ44gdlEMREu6dzX1DlAaH/qSykSVzdrdafA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-trace-otlp-http@0.218.0':
+    resolution: {integrity: sha512-8dqezsmPhtKitIK/eTipZhYl9EX2/gNQ5zUMhaz3uxEURwfkNf8IPvo6yNfrzbxdtpAOybS/+h7wmIWYqFSpiw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-trace-otlp-proto@0.218.0':
+    resolution: {integrity: sha512-r1Msf8SNLRmwh9J6XQ5uh82D7CdDWMNHnPB7LAVHjzut0TkSeKc5KcIvr4SvHvfk/xwN5gxC+VLKQ1k0o8PSPw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-zipkin@2.7.1':
+    resolution: {integrity: sha512-mfsD9bKAxcKrh5+y08TPodvClBO0CznBE3p79YAGnO81WI4LrdsGA65T53e4iTSbCalW4WaUpkbeJcbpyIUHfg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+
+  '@opentelemetry/instrumentation@0.218.0':
+    resolution: {integrity: sha512-mIZil8Es+sYDK5m+DQiwAwF57F14TF2YlEqvIjZ/RQWcxDBwRGsKfdK2Tv65OU9meQKCMzSIFS9mxAcnAb6Bkg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-exporter-base@0.200.0':
+    resolution: {integrity: sha512-IxJgA3FD7q4V6gGq4bnmQM5nTIyMDkoGFGrBrrDjB6onEiq1pafma55V+bHvGYLWvcqbBbRfezr1GED88lacEQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-exporter-base@0.218.0':
+    resolution: {integrity: sha512-ZwqpkNL5W7RyGJPDZ9g06DvKp8KFTWPJPN12anpMQYSKpTSU0z3EIZuPq9vPGpS8siFyOqDYDAuCwlNO9FqgbA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-grpc-exporter-base@0.218.0':
+    resolution: {integrity: sha512-H/lCGJ536N98VpYJOaWTQOkv4Dx6TnmStK6Rqfu1W7KkFbPAx04hjdYEMZF/YbnHzPUSIK4kM6OE2GKGBTpV9A==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-transformer@0.200.0':
+    resolution: {integrity: sha512-+9YDZbYybOnv7sWzebWOeK6gKyt2XE7iarSyBFkwwnP559pEevKOUD8NyDHhRjCSp13ybh9iVXlMfcj/DwF/yw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-transformer@0.218.0':
+    resolution: {integrity: sha512-CFaKH87WAzjuJ4awowTTLzUvMfaRfiOFG5+qm5S5ncyalRtN4ecQ+YmuANJSCrVPuvZFEkUgKhBPBndxi3rHsQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/propagator-b3@2.7.1':
+    resolution: {integrity: sha512-RJid6E2CKyeGfKBzXKF21ejabGMHypFkPAh3qZ+NvI+SGjuIye79t3PmiqcDgtRzdKH6ynXzbfslQ8DfpRUg2A==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/propagator-jaeger@2.7.1':
+    resolution: {integrity: sha512-KMjVBHzP4N60bOzxja76M1F1hZZ43lGPga5ix+mkv9+kk1nx9SbkxSvJsMbuVUxdPQmsPTqGShmhN8ulrMOg6Q==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/resources@2.0.0':
+    resolution: {integrity: sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/resources@2.10.0':
+    resolution: {integrity: sha512-q6MMm2zhggzsHVNbabYwut+a6nbuQQe3URUoxaojM/8K1IBfwwPzvxIjNi2/lI1TFe+fMHMW9MWhrtDLEXEnkA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/resources@2.7.1':
+    resolution: {integrity: sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-logs@0.200.0':
+    resolution: {integrity: sha512-VZG870063NLfObmQQNtCVcdXXLzI3vOjjrRENmU37HYiPFa0ZXpXVDsTD02Nh3AT3xYJzQaWKl2X2lQ2l7TWJA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.4.0 <1.10.0'
+
+  '@opentelemetry/sdk-logs@0.218.0':
+    resolution: {integrity: sha512-QvnNdugatFTVCJXH0Mcu7GOOJSylA9j127kIezOE4YwTI4YbowRons2K4WZTv5FMS8T4q9P0NdaRHdkSmeAIag==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.4.0 <1.10.0'
+
+  '@opentelemetry/sdk-metrics@2.0.0':
+    resolution: {integrity: sha512-Bvy8QDjO05umd0+j+gDeWcTaVa1/R2lDj/eOvjzpm8VQj1K1vVZJuyjThpV5/lSHyYW2JaHF2IQ7Z8twJFAhjA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.9.0 <1.10.0'
+
+  '@opentelemetry/sdk-metrics@2.7.1':
+    resolution: {integrity: sha512-MpDJdkiFDs3Pm1RHO3KByuZbuBdJEXEAkiC0+yJdsZGVCdf1RpHR6n+LHDcS7ffmfrt5kVCzJSCfm4z2C7v0uQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.9.0 <1.10.0'
+
+  '@opentelemetry/sdk-node@0.218.0':
+    resolution: {integrity: sha512-tPMjHrLV5gsfNdYqoRHjeGbCAZBXXD9c1Qo/2ut7VwnUABDNh76xNxrT0SEhkIIJuCN45bbN1vZnYL1gY0IkOg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@2.0.0':
+    resolution: {integrity: sha512-qQnYdX+ZCkonM7tA5iU4fSRsVxbFGml8jbxOgipRGMFHKaXKHQ30js03rTobYjKjIfnOsZSbHKWF0/0v0OQGfw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@2.10.0':
+    resolution: {integrity: sha512-GuYQQT7QD2EeO8lcZLRQzcbOyhqAzL+6WWTKTU9mSUBYBazkEDl+VrQcXQhbB08OWM9anD1aHleVadzulpOaUQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@2.7.1':
+    resolution: {integrity: sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-node@2.10.0':
+    resolution: {integrity: sha512-GZK/G6oZyBLGlH1pUgeDch7D91KoHd2uotUGIkWCPi9GI5T9X0p4L7nNAMDR1BQjkRYoDqo+ddfVx9t5Uhys+Q==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-node@2.7.1':
+    resolution: {integrity: sha512-pCpQxU68lV+I9s9svqMyVu5iHdDDUnqUpSxqwyCU8A9ejEsSnMPCbearwsUO4yk08ZJzAIUCFuReMdVQvHrdvg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace@2.10.0':
+    resolution: {integrity: sha512-MfQGq3GRmTh5fM/y+OjaO0vj6+luCB1XO2gfXCalKCfgKw0eHL++sm75DNweC6ohlp+aFvACqeE0fYayqdRaoQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
 
   '@opentelemetry/semantic-conventions@1.43.0':
     resolution: {integrity: sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==}
@@ -7720,6 +8233,9 @@ packages:
     resolution: {integrity: sha512-trO//ypJBSt5xkewuol9LOykvDgHwUXq8R+yQVS+0CmpN3lYUtewHkb+At9RVGRhDMmJZY2oasaXDnhfurQ33w==}
     hasBin: true
 
+  '@sec-ant/readable-stream@0.4.1':
+    resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
+
   '@secure-exec/core@0.2.1':
     resolution: {integrity: sha512-HsnUv6gClpMA1BBRmX86j30TKTZtgJC/fO1tVavr7IpM2zNKbHU8LgSlBd7mv2SNy02ImTmU/GnQ3aYB4NSbEg==}
 
@@ -7809,9 +8325,25 @@ packages:
   '@sinclair/typebox@0.34.49':
     resolution: {integrity: sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==}
 
+  '@sindresorhus/is@4.6.0':
+    resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
+    engines: {node: '>=10'}
+
+  '@sindresorhus/merge-streams@4.0.0':
+    resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
+    engines: {node: '>=18'}
+
+  '@sindresorhus/slugify@2.2.1':
+    resolution: {integrity: sha512-MkngSCRZ8JdSOCHRaYd+D01XhvU3Hjy6MGl06zhOk614hp9EOAp5gIkBeQg7wtmxpitU6eAL4kdiRMcJa2dlrw==}
+    engines: {node: '>=12'}
+
   '@sindresorhus/slugify@3.0.0':
     resolution: {integrity: sha512-SCrKh1zS96q+CuH5GumHcyQEVPsM4Ve8oE0E6tw7AAhGq50K8ojbTUOQnX/j9Mhcv/AXiIsbCfquovyGOo5fGw==}
     engines: {node: '>=20'}
+
+  '@sindresorhus/transliterate@1.6.0':
+    resolution: {integrity: sha512-doH1gimEu3A46VX6aVxpHTeHrytJAG6HgdxntYnCFiIFHEM/ZGpG8KiZGBChchjQmG0XFIBL552kBTjVcMZXwQ==}
+    engines: {node: '>=12'}
 
   '@sindresorhus/transliterate@2.3.1':
     resolution: {integrity: sha512-gVaaGtKYMYAMmI8buULVH3A2TXVJ98QiwGwI7ddrWGuGidGC2uRt4FHs22+8iROJ0QTzju9CuMjlVsrvpqsdhA==}
@@ -8301,6 +8833,9 @@ packages:
   '@types/node-fetch@2.6.13':
     resolution: {integrity: sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==}
 
+  '@types/node@16.9.1':
+    resolution: {integrity: sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==}
+
   '@types/node@18.19.130':
     resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
 
@@ -8493,6 +9028,69 @@ packages:
   '@volar/typescript@1.11.1':
     resolution: {integrity: sha512-iU+t2mas/4lYierSnoFOeRFQUhAEMgsFuQxoxvwn5EdQopw43j+J27a4lt9LMInx1gLJBC6qL14WYGlgymaSMQ==}
 
+  '@vscode/ripgrep-darwin-arm64@1.18.0':
+    resolution: {integrity: sha512-r3ktHSvbFycQNF6sl7sNDPocpsI7J+mEzh1IaZFkY0spm3k2Z9t8hPAeOK7+p0l6p6/swkQC14XWX01low+94Q==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@vscode/ripgrep-darwin-x64@1.18.0':
+    resolution: {integrity: sha512-25b4gWbL138dGuQU244ebCKKc0q05ULBMoFSz9oAEUHNeqK/lOJViDS7DRvbDazzAzSEdan391Znks/R5mkaTQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@vscode/ripgrep-linux-arm64@1.18.0':
+    resolution: {integrity: sha512-lQ/5zTG++U0E3IhVgS4EPTTn/U4okncaRMM5GOFfOYZywS4nuD31GhkHbNYlDk5CuDC68+hYJ0/eQeyCKJDA+g==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@vscode/ripgrep-linux-arm@1.18.0':
+    resolution: {integrity: sha512-GDAvufNDHu8zqLEmXstalQF0Wh6wQvdsBi/Vg3Yi3CK4a8XoFXqqXVEHEZ9xQz3t0NfoSEc9JbvK9DDS6FxyxQ==}
+    cpu: [arm]
+    os: [linux]
+
+  '@vscode/ripgrep-linux-ia32@1.18.0':
+    resolution: {integrity: sha512-YWLkSUtFd4Jh5EepIhA9RJSfv3uMAVMo+2rBIGHPBnvgLrZciIs2cDKei1/p6Wc/aCzUoHyMAg2R6tw4ZCBKGg==}
+    cpu: [ia32]
+    os: [linux]
+
+  '@vscode/ripgrep-linux-ppc64@1.18.0':
+    resolution: {integrity: sha512-quXVY8fwQ8O/lvU1yrSqSl3jlUzysRSb+AfUfCL/tRtphxsKlFvPAejryZ6vg4Bgvn8XL74xb4qMCDmWgYrT5w==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@vscode/ripgrep-linux-riscv64@1.18.0':
+    resolution: {integrity: sha512-f5kBQBrWfQt8Q7OhSORuNDei5dkYagBj3y4jImSUXGMy8B/Ke7SltSRcUtjPv166FAFfHCAmWuZp3+cWnX2/Vw==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@vscode/ripgrep-linux-s390x@1.18.0':
+    resolution: {integrity: sha512-rTOcJFGGcl2c07RUOWUo4U1ndnemKhY6A9hnMB18uk7jSgJc0d/QLBGWMWpumdtoJtpizn/wIv5mXIisJukusQ==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@vscode/ripgrep-linux-x64@1.18.0':
+    resolution: {integrity: sha512-mQ3bVrUpnD2vs7QT0vX90Lt0cnUq467uFtEktIdsJJmW296RoSULRGqWgzG1AKxyBpNDD6l4ZO4qKf6SgyC23Q==}
+    cpu: [x64]
+    os: [linux]
+
+  '@vscode/ripgrep-win32-arm64@1.18.0':
+    resolution: {integrity: sha512-vfTIjq1OHnzUjxZcHVQAMbnggp8dpGf+0QKFOZHwWPqFwXxQC8eCWM+5NUdoJ6yrElCeMzoUTXoK/LdZaniB+Q==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@vscode/ripgrep-win32-ia32@1.18.0':
+    resolution: {integrity: sha512-//rfAE+BOw5AC2EMmepmiE36jUuevtQYNQqqlw1s3m9FlRxjxEut97RkRPHAu9BG4mSojatZx+kXZXNdyI9caQ==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@vscode/ripgrep-win32-x64@1.18.0':
+    resolution: {integrity: sha512-KNPvtElldqILHdnAetujPaowkNbpqJy3ssIGGN6F6Kve9Qi+nNLI2DN01O83JjCEVQbCzl8Ov3QZ9Eov3BR8Dg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@vscode/ripgrep@1.18.0':
+    resolution: {integrity: sha512-ns5lWe44tSfbTMbVUsyB+I1819PVSw4AdpgK0RNkzfWfwy6+3IUNSxwSrfTno1/oWaS/hERNz+XLWVyga2aJBQ==}
+
   '@vue/compiler-core@3.5.40':
     resolution: {integrity: sha512-39E8IgOhTbVDnoJFMKc2DvYnypcZwUqgUhQkccva/0m6FUwtIKSGV7n1hpVmYcFaoRAwf9pBcwnKlCEsN63ZEQ==}
 
@@ -8608,6 +9206,10 @@ packages:
     resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
     engines: {node: '>=8'}
 
+  ansi-escapes@7.3.0:
+    resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
+    engines: {node: '>=18'}
+
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
@@ -8631,6 +9233,9 @@ packages:
   ansis@3.17.0:
     resolution: {integrity: sha512-0qWUglt9JEqLFr3w1I1pbrChn1grhaiAR2ocX1PP/flRmxgtwTzPFFFnfIlD6aMOLQZgSuCRlidD70lvx8yhzg==}
     engines: {node: '>=14'}
+
+  any-base@1.1.0:
+    resolution: {integrity: sha512-uMgjozySS8adZZYePpaWs8cxB9/kdzmpX6SgJZ+wbz1K5eYk5QMYDVJaZKhxyIHUdnnJkfR7SVgStgH7LkGUyg==}
 
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
@@ -8706,6 +9311,10 @@ packages:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
     engines: {node: '>=8.0.0'}
 
+  auto-bind@5.0.1:
+    resolution: {integrity: sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   autoprefixer@10.5.0:
     resolution: {integrity: sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==}
     engines: {node: ^10 || ^12 || >=14}
@@ -8716,6 +9325,10 @@ packages:
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
+
+  await-to-js@3.0.0:
+    resolution: {integrity: sha512-zJAaP9zxTcvTHRlejau3ZOY4V7SRpiByf3/dxx2uyKxxor19tpmpV2QRsTKikckwhaPmr2dVpxxMr7jOCYVp5g==}
+    engines: {node: '>=6.0.0'}
 
   aws4fetch@1.0.20:
     resolution: {integrity: sha512-/djoAN709iY65ETD6LKCtyyEI04XIBP5xVvfmNxsEP0uJB5tyaGBztSryRr4HqMStr9R06PisQE7m9zDTXKu6g==}
@@ -8821,6 +9434,9 @@ packages:
 
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+
+  bmp-ts@1.0.9:
+    resolution: {integrity: sha512-cTEHk2jLrPyi+12M3dhpEbnnPOsaZuq7C45ylbbQIiWgDFZq4UVYPEY5mlqjvsj/6gJv9qX5sa+ebDzLXT28Vw==}
 
   bn.js@4.12.4:
     resolution: {integrity: sha512-njR1b+ixG2ufvL9Zn9JGneW+b5GV6jqpYyPPpg4QVt723b5kJPGUczkUyWEH9BwEA74UakJZ43I4FDLBF7ci0g==}
@@ -8995,6 +9611,10 @@ packages:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
+  char-regex@1.0.2:
+    resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
+    engines: {node: '>=10'}
+
   character-entities-html4@2.1.0:
     resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
 
@@ -9058,6 +9678,18 @@ packages:
     resolution: {integrity: sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==}
     engines: {node: '>=10'}
 
+  cli-boxes@4.0.1:
+    resolution: {integrity: sha512-5IOn+jcCEHEraYolBPs/sT4BxYCe2nHg374OPiItB1O96KZFseS2gthU4twyYzeDcFew4DaUM/xwc5BQf08JJw==}
+    engines: {node: '>=18.20 <19 || >=20.10'}
+
+  cli-cursor@4.0.0:
+    resolution: {integrity: sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  cli-cursor@5.0.0:
+    resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
+    engines: {node: '>=18'}
+
   cli-highlight@2.1.11:
     resolution: {integrity: sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==}
     engines: {node: '>=8.0.0', npm: '>=5.0.0'}
@@ -9066,6 +9698,18 @@ packages:
   cli-spinners@2.9.2:
     resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
     engines: {node: '>=6'}
+
+  cli-spinners@3.4.0:
+    resolution: {integrity: sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw==}
+    engines: {node: '>=18.20'}
+
+  cli-table3@0.6.5:
+    resolution: {integrity: sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==}
+    engines: {node: 10.* || >= 12.*}
+
+  cli-truncate@6.1.1:
+    resolution: {integrity: sha512-06p9vyLahLa4zkGcgsGxU6iEkSOiuI4fhCH6Emhe2lPAcoUv73n72DnODsnHA+5wwXGnV0n9M9/qOQJSjYhFhw==}
+    engines: {node: '>=22'}
 
   cliui@7.0.4:
     resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
@@ -9083,6 +9727,10 @@ packages:
     peerDependencies:
       react: ^18 || ^19 || ^19.0.0-rc
       react-dom: ^18 || ^19 || ^19.0.0-rc
+
+  code-excerpt@4.0.0:
+    resolution: {integrity: sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   codemirror@6.0.2:
     resolution: {integrity: sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==}
@@ -9113,6 +9761,11 @@ packages:
 
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
+
+  command-code@1.1.0:
+    resolution: {integrity: sha512-qC5qWZfgFvZCJbDasIMOW5XMR0tGUVjqOT4RU6ke0neE4pPemuy+XJUlUqf+v3FdKwjIe9BLmqiHgG/AD1yY3Q==}
+    engines: {node: '>=22'}
+    hasBin: true
 
   commander@11.1.0:
     resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
@@ -9186,6 +9839,10 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  convert-to-spaces@2.0.1:
+    resolution: {integrity: sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   cookie-es@1.2.3:
     resolution: {integrity: sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==}
@@ -9660,8 +10317,104 @@ packages:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
     engines: {node: '>=12'}
 
+  dotenv@17.4.2:
+    resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
+    engines: {node: '>=12'}
+
   drizzle-orm@0.44.7:
     resolution: {integrity: sha512-quIpnYznjU9lHshEOAYLoZ9s3jweleHlZIAWR/jX9gAWNg/JhQ1wj0KGRf7/Zm+obRrYd9GjPVJg790QY9N5AQ==}
+    peerDependencies:
+      '@aws-sdk/client-rds-data': '>=3'
+      '@cloudflare/workers-types': '>=4'
+      '@electric-sql/pglite': '>=0.2.0'
+      '@libsql/client': '>=0.10.0'
+      '@libsql/client-wasm': '>=0.10.0'
+      '@neondatabase/serverless': '>=0.10.0'
+      '@op-engineering/op-sqlite': '>=2'
+      '@opentelemetry/api': ^1.4.1
+      '@planetscale/database': '>=1.13'
+      '@prisma/client': '*'
+      '@tidbcloud/serverless': '*'
+      '@types/better-sqlite3': '*'
+      '@types/pg': '*'
+      '@types/sql.js': '*'
+      '@upstash/redis': '>=1.34.7'
+      '@vercel/postgres': '>=0.8.0'
+      '@xata.io/client': '*'
+      better-sqlite3: '>=7'
+      bun-types: '*'
+      expo-sqlite: '>=14.0.0'
+      gel: '>=2'
+      knex: '*'
+      kysely: '*'
+      mysql2: '>=2'
+      pg: '>=8'
+      postgres: '>=3'
+      prisma: '*'
+      sql.js: '>=1'
+      sqlite3: '>=5'
+    peerDependenciesMeta:
+      '@aws-sdk/client-rds-data':
+        optional: true
+      '@cloudflare/workers-types':
+        optional: true
+      '@electric-sql/pglite':
+        optional: true
+      '@libsql/client':
+        optional: true
+      '@libsql/client-wasm':
+        optional: true
+      '@neondatabase/serverless':
+        optional: true
+      '@op-engineering/op-sqlite':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@planetscale/database':
+        optional: true
+      '@prisma/client':
+        optional: true
+      '@tidbcloud/serverless':
+        optional: true
+      '@types/better-sqlite3':
+        optional: true
+      '@types/pg':
+        optional: true
+      '@types/sql.js':
+        optional: true
+      '@upstash/redis':
+        optional: true
+      '@vercel/postgres':
+        optional: true
+      '@xata.io/client':
+        optional: true
+      better-sqlite3:
+        optional: true
+      bun-types:
+        optional: true
+      expo-sqlite:
+        optional: true
+      gel:
+        optional: true
+      knex:
+        optional: true
+      kysely:
+        optional: true
+      mysql2:
+        optional: true
+      pg:
+        optional: true
+      postgres:
+        optional: true
+      prisma:
+        optional: true
+      sql.js:
+        optional: true
+      sqlite3:
+        optional: true
+
+  drizzle-orm@0.45.2:
+    resolution: {integrity: sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q==}
     peerDependencies:
       '@aws-sdk/client-rds-data': '>=3'
       '@cloudflare/workers-types': '>=4'
@@ -9789,6 +10542,9 @@ packages:
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
+  emojilib@2.4.0:
+    resolution: {integrity: sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==}
+
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
@@ -9808,6 +10564,10 @@ packages:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
 
+  env-editor@1.3.0:
+    resolution: {integrity: sha512-EqiD/j01PooUbeWk+etUo2TWoocjoxMfGNYpS9e47glIJ5r8WepycIki+LCbonFbPdwlqY5ETeSTAJVMih4z4w==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   env-runner@0.1.16:
     resolution: {integrity: sha512-2LRJM4P2KLX6J83QZZrMqvgCDt/D5ea7wPcI3yYiy5cG/9rX5QwdwZFx0D7ktWnjdRyZxYjttGGorb5nFqb1CA==}
     hasBin: true
@@ -9826,6 +10586,10 @@ packages:
       wrangler:
         optional: true
 
+  environment@1.1.0:
+    resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
+    engines: {node: '>=18'}
+
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
     engines: {node: '>= 0.4'}
@@ -9836,6 +10600,9 @@ packages:
 
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  es-module-lexer@2.3.1:
+    resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
@@ -9875,6 +10642,10 @@ packages:
 
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
+  escape-string-regexp@2.0.0:
+    resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
+    engines: {node: '>=8'}
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -9993,6 +10764,13 @@ packages:
     resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
     engines: {node: '>=16.17'}
 
+  execa@9.6.1:
+    resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
+    engines: {node: ^18.19.0 || >=20.5.0}
+
+  exif-parser@0.1.12:
+    resolution: {integrity: sha512-c2bQfLNbMzLPmzQuOr8fy0csy84WmwnER81W88DzTp9CYNPJ6yzOj2EZAh9pywYpqHnshVLHQJ8WzldAyfY+Iw==}
+
   expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
     engines: {node: '>=6'}
@@ -10048,8 +10826,17 @@ packages:
   fast-sha256@1.3.0:
     resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
 
+  fast-string-truncated-width@3.0.3:
+    resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
+
+  fast-string-width@3.0.2:
+    resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
+
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
+  fast-wrap-ansi@0.2.2:
+    resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
 
   fast-xml-builder@1.1.4:
     resolution: {integrity: sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==}
@@ -10089,6 +10876,10 @@ packages:
 
   fflate@0.4.9:
     resolution: {integrity: sha512-zdxgIEddhfsyCaWpJ2SdXEP8ZMrKJ6+5jl4OupODcywU0IhRk6gdXuVGcPICyfx2H97hVK7xmJtRLPjkxAX8Vw==}
+
+  figures@6.1.0:
+    resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
+    engines: {node: '>=18'}
 
   file-type@21.3.4:
     resolution: {integrity: sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==}
@@ -10289,12 +11080,23 @@ packages:
     resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
     engines: {node: '>=16'}
 
+  get-stream@9.0.1:
+    resolution: {integrity: sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==}
+    engines: {node: '>=18'}
+
   get-tsconfig@4.13.7:
     resolution: {integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==}
 
   get-uri@6.0.5:
     resolution: {integrity: sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==}
     engines: {node: '>= 14'}
+
+  gifwrap@0.10.1:
+    resolution: {integrity: sha512-2760b1vpJHNmLzZ/ubTtNnEx5WApN/PYWJvXvgS+tL1egTTthayFYIQQNi136FLEDcN/IyEY2EcGpIITD6eYUw==}
+
+  giget@3.3.0:
+    resolution: {integrity: sha512-gzi2D96p+AMfDcmJHGDj3KJ9NRiwvlFAU5yfa3ROwWZmFUjX4P43x3BcyRaOMMLto1vUo7C+86+MFhYTl6Ryiw==}
+    hasBin: true
 
   github-from-package@0.0.0:
     resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
@@ -10373,6 +11175,10 @@ packages:
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+
+  has-flag@5.0.1:
+    resolution: {integrity: sha512-CsNUt5x9LUdx6hnk/E2SZLsDyvfqANZSUq4+D3D8RzDJ2M+HDTIkF60ibS1vHaK55vzgiZw1bEPFG9yH7l33wA==}
+    engines: {node: '>=12'}
 
   has-property-descriptors@1.0.2:
     resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
@@ -10518,6 +11324,10 @@ packages:
     resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
     engines: {node: '>=16.17.0'}
 
+  human-signals@8.0.1:
+    resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
+    engines: {node: '>=18.18.0'}
+
   humanize-ms@1.2.1:
     resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
 
@@ -10536,8 +11346,15 @@ packages:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
+  image-q@4.0.0:
+    resolution: {integrity: sha512-PfJGVgIfKQJuq3s0tTDOKtztksibuUEbJQIYT3by6wctQo+Rdlh7ef4evJ5NCdxY4CfMbvFkocEwbl4BF8RlJw==}
+
   immediate@3.0.6:
     resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
+
+  import-in-the-middle@3.3.2:
+    resolution: {integrity: sha512-jTd2FfOgOWOdgjkHuk/1Ms8VKFXkPs15ymYBETw1sAOrO/dY3XeGVRWir9qBbw7pXr0T2eTFwfCZ+N02HmiNGA==}
+    engines: {node: '>=18'}
 
   import-lazy@4.0.0:
     resolution: {integrity: sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==}
@@ -10550,11 +11367,35 @@ packages:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
 
+  indent-string@5.0.0:
+    resolution: {integrity: sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==}
+    engines: {node: '>=12'}
+
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+
+  ink-spinner@5.0.0:
+    resolution: {integrity: sha512-EYEasbEjkqLGyPOUc8hBJZNuC5GvXGMLu0w5gdTNskPc7Izc5vO3tdQEYnzvshucyGCBXc86ig0ujXPMWaQCdA==}
+    engines: {node: '>=14.16'}
+    peerDependencies:
+      ink: '>=4.0.0'
+      react: '>=18.0.0'
+
+  ink@7.1.0:
+    resolution: {integrity: sha512-VWE6/yeLtFCJBNLflyI2OSylyXK1Rc24LuXup8Qt+icwkmmycFNdbn8IkSp6Frc0h1iA0NOvvi1ajW44U/w3Qg==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      '@types/react': '>=19.2.0'
+      react: '>=19.2.0'
+      react-devtools-core: '>=6.1.2'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      react-devtools-core:
+        optional: true
 
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
@@ -10632,6 +11473,10 @@ packages:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
 
+  is-fullwidth-code-point@5.1.0:
+    resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
+    engines: {node: '>=18'}
+
   is-generator-function@1.1.2:
     resolution: {integrity: sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==}
     engines: {node: '>= 0.4'}
@@ -10643,10 +11488,19 @@ packages:
   is-hexadecimal@2.0.1:
     resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
 
+  is-in-ci@2.0.0:
+    resolution: {integrity: sha512-cFeerHriAnhrQSbpAxL37W1wcJKUUX07HyLWZCW1URJT/ra3GyUTzBgUnh24TMVfNTV2Hij2HLxkPHFZfOZy5w==}
+    engines: {node: '>=20'}
+    hasBin: true
+
   is-inside-container@1.0.0:
     resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
     engines: {node: '>=14.16'}
     hasBin: true
+
+  is-interactive@2.0.0:
+    resolution: {integrity: sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==}
+    engines: {node: '>=12'}
 
   is-nan@1.3.2:
     resolution: {integrity: sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==}
@@ -10679,9 +11533,17 @@ packages:
     resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  is-stream@4.0.1:
+    resolution: {integrity: sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==}
+    engines: {node: '>=18'}
+
   is-typed-array@1.1.15:
     resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
     engines: {node: '>= 0.4'}
+
+  is-unicode-supported@2.1.0:
+    resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
+    engines: {node: '>=18'}
 
   is-wsl@2.2.0:
     resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
@@ -10715,6 +11577,10 @@ packages:
     resolution: {integrity: sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  jimp@1.6.1:
+    resolution: {integrity: sha512-hNQh6rZtWfSVWSNVmvq87N5BPJsNH7k7I7qyrXf9DOma9xATQk3fsyHazCQe51nCjdkoWdTmh0vD7bjVSLoxxw==}
+    engines: {node: '>=18'}
 
   jiti@1.21.7:
     resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
@@ -10760,6 +11626,9 @@ packages:
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
+
+  jpeg-js@0.4.4:
+    resolution: {integrity: sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==}
 
   js-tiktoken@1.0.21:
     resolution: {integrity: sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g==}
@@ -10872,6 +11741,10 @@ packages:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
     engines: {node: '>=14'}
 
+  line-column-path@3.0.0:
+    resolution: {integrity: sha512-Atocnm7Wr9nuvAn97yEPQa3pcQI5eLQGBz+m6iTb+CVw+IOzYB9MrYK7jI7BfC9ISnT4Fu0eiwhAScV//rp4Hw==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
@@ -10912,6 +11785,10 @@ packages:
 
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
+
+  log-symbols@7.0.1:
+    resolution: {integrity: sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==}
+    engines: {node: '>=18'}
 
   loglevel@1.9.2:
     resolution: {integrity: sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==}
@@ -10980,6 +11857,12 @@ packages:
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
+  marked-terminal@7.3.0:
+    resolution: {integrity: sha512-t4rBvPsHc57uE/2nJOLmMbZCQ4tgAccAED3ngXQqW6g+TxA488JzJ+FK3lQkzBQOI1mRV/r/Kq+1ZlJ4D0owQw==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      marked: '>=1 <16'
 
   marked@15.0.12:
     resolution: {integrity: sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==}
@@ -11224,6 +12107,11 @@ packages:
     resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
     engines: {node: '>=18'}
 
+  mime@3.0.0:
+    resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
+    engines: {node: '>=10.0.0'}
+    hasBin: true
+
   mime@4.1.0:
     resolution: {integrity: sha512-X5ju04+cAzsojXKes0B/S4tcYtFAJ6tTMuSPBEn9CPGlrWr8Fiw7qYeLT0XyH80HSoAoqWCaz+MWKh22P7G1cw==}
     engines: {node: '>=16'}
@@ -11236,6 +12124,10 @@ packages:
   mimic-fn@4.0.0:
     resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
     engines: {node: '>=12'}
+
+  mimic-function@5.0.1:
+    resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
+    engines: {node: '>=18'}
 
   mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
@@ -11281,6 +12173,9 @@ packages:
 
   mlly@1.8.2:
     resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
+
+  module-details-from-path@1.0.4:
+    resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
 
   monaco-editor@0.52.2:
     resolution: {integrity: sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==}
@@ -11383,6 +12278,10 @@ packages:
     engines: {node: '>=10.5.0'}
     deprecated: Use your platform's native DOMException instead
 
+  node-emoji@2.2.0:
+    resolution: {integrity: sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==}
+    engines: {node: '>=18'}
+
   node-fetch-native@1.6.7:
     resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
 
@@ -11436,6 +12335,10 @@ packages:
   npm-run-path@5.3.0:
     resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  npm-run-path@6.0.0:
+    resolution: {integrity: sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==}
+    engines: {node: '>=18'}
 
   npm@11.18.0:
     resolution: {integrity: sha512-T67M4L5wNm0cZ7EBLErcEkY1SmzEW/WJ+SADBzsFUY1UdAPfFHXFQtZ6SEXiK0+vzXysCvAsepbMaBTwnrAD+w==}
@@ -11553,6 +12456,9 @@ packages:
     peerDependencies:
       zod: ^4.0.16
 
+  omggif@1.0.10:
+    resolution: {integrity: sha512-LMJTtvgc/nugXj0Vcrrs68Mn2D1r0zf630VNtqtpI1FEO7e+O9FP4gqs9AcnBaSEeoHIPm28u6qgPR0oyEpGSw==}
+
   on-exit-leak-free@2.1.2:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
     engines: {node: '>=14.0.0'}
@@ -11572,11 +12478,19 @@ packages:
     resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
     engines: {node: '>=12'}
 
+  onetime@7.0.0:
+    resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
+    engines: {node: '>=18'}
+
   oniguruma-parser@0.12.2:
     resolution: {integrity: sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==}
 
   oniguruma-to-es@4.3.6:
     resolution: {integrity: sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==}
+
+  open-editor@5.1.0:
+    resolution: {integrity: sha512-KkNqM6FdoegD6WhY2YXmWcovOux45NV+zBped2+G3+V74zkDPkIl4cqh6hte2zNDojtwO2nBOV8U+sgziWfPrg==}
+    engines: {node: '>=18'}
 
   open@10.2.0:
     resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
@@ -11675,6 +12589,10 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  ora@9.4.1:
+    resolution: {integrity: sha512-6VlU9MLXbjVQD04AZCMX28hVtA5bUoadvUqO76MUCVA0ilwJbMiHsITRPfyVm6p/BC0Av/BXMujx39WCe1LEqw==}
+    engines: {node: '>=20'}
+
   os-browserify@0.3.0:
     resolution: {integrity: sha512-gjcpUc3clBf9+210TRaDWbf+rZZZEshZ+DlXMRCeAjp0xhTrnQsKHypIy1J3d5hKdUzj69t708EHtU8P6bUn0A==}
 
@@ -11743,11 +12661,24 @@ packages:
     resolution: {integrity: sha512-fIYNuZ/HastSb80baGOuPRo1O9cf4baWw5WsAp7dBuUzeTD/BoaG8sVTdlPFksBE2lF21dN+A1AnrpIjSWqHHg==}
     engines: {node: '>= 0.10'}
 
+  parse-bmfont-ascii@1.0.6:
+    resolution: {integrity: sha512-U4RrVsUFCleIOBsIGYOMKjn9PavsGOXxbvYGtMOEfnId0SVNsgehXh1DxUdVPLoxd5mvcEtvmKs2Mmf0Mpa1ZA==}
+
+  parse-bmfont-binary@1.0.6:
+    resolution: {integrity: sha512-GxmsRea0wdGdYthjuUeWTMWPqm2+FAd4GI8vCvhgJsFnoGhTrLhXDDupwTo7rXVAgaLIGoVHDZS9p/5XbSqeWA==}
+
+  parse-bmfont-xml@1.1.6:
+    resolution: {integrity: sha512-0cEliVMZEhrFDwMh4SxIyVJpqYoOWDJ9P895tFuS+XuNzI5UBmBk5U5O4KuJdTnZpSBI4LFA2+ZiJaiwfSwlMA==}
+
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
 
   parse-latin@7.0.0:
     resolution: {integrity: sha512-mhHgobPPua5kZ98EF4HWiH167JWBfl4pvAIXXdbaVohtK7a6YBOy56kvhCqduqyo/f3yrHFWmqmiMg/BkBkYYQ==}
+
+  parse-ms@4.0.0:
+    resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
+    engines: {node: '>=18'}
 
   parse5-htmlparser2-tree-adapter@6.0.1:
     resolution: {integrity: sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==}
@@ -11767,6 +12698,10 @@ packages:
 
   partial-json@0.1.7:
     resolution: {integrity: sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==}
+
+  patch-console@2.0.0:
+    resolution: {integrity: sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   patchright-core@1.59.4:
     resolution: {integrity: sha512-7/vyX0XK0cpGKlcnUD+Rhjv5o9rrmZQl4v/NI+EUBed+VaU5EORpkOF0Gdi+fP698fLhY0tXwacKBUqKE38jQA==}
@@ -11879,6 +12814,10 @@ packages:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
 
+  pixelmatch@5.3.0:
+    resolution: {integrity: sha512-o8mkY4E/+LNUf6LzX96ht6k6CEDi65k9G2rjMtBe9Oo+VPKSvl+0GKHuH/AlG+GA5LPG/i5hrekkxUc3s2HU+Q==}
+    hasBin: true
+
   pkce-challenge@5.0.1:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
@@ -11899,6 +12838,14 @@ packages:
     resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
     engines: {node: '>=18'}
     hasBin: true
+
+  pngjs@6.0.0:
+    resolution: {integrity: sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg==}
+    engines: {node: '>=12.13.0'}
+
+  pngjs@7.0.0:
+    resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
+    engines: {node: '>=14.19.0'}
 
   points-on-curve@0.2.0:
     resolution: {integrity: sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==}
@@ -11973,6 +12920,10 @@ packages:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  postgres@3.4.9:
+    resolution: {integrity: sha512-GD3qdB0x1z9xgFI6cdRD6xu2Sp2WCOEoe3mtnyB5Ee0XrrL5Pe+e4CCnJrRMnL1zYtRDZmQQVbvOttLnKDLnaw==}
+    engines: {node: '>=12'}
+
   posthog-js@1.406.2:
     resolution: {integrity: sha512-HNJO6Llro79s3x/ScxGY7i+Tf/o+ctJkOc79vrnS6R1I3TzucfzfwgAip1JVnQHnkBPV4JE8hI6nUXMJdU113Q==}
 
@@ -11989,6 +12940,10 @@ packages:
     engines: {node: '>=10'}
     deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
     hasBin: true
+
+  pretty-ms@9.3.0:
+    resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
+    engines: {node: '>=18'}
 
   prismjs@1.30.0:
     resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
@@ -12142,6 +13097,12 @@ packages:
     peerDependencies:
       '@types/react': '>=18'
       react: '>=18'
+
+  react-reconciler@0.33.0:
+    resolution: {integrity: sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA==}
+    engines: {node: '>=0.10.0'}
+    peerDependencies:
+      react: ^19.2.0
 
   react-refresh@0.17.0:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
@@ -12352,6 +13313,10 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
+  require-in-the-middle@8.0.1:
+    resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
+    engines: {node: '>=9.3.0 || >=8.10.0 <9.0.0'}
+
   resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
@@ -12366,6 +13331,14 @@ packages:
     resolution: {integrity: sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==}
     engines: {node: '>= 0.4'}
     hasBin: true
+
+  restore-cursor@4.0.0:
+    resolution: {integrity: sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  restore-cursor@5.1.0:
+    resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
+    engines: {node: '>=18'}
 
   retext-latin@4.0.0:
     resolution: {integrity: sha512-hv9woG7Fy0M9IlRQloq/N6atV82NxLGveq+3H2WOi79dtIYWN8OaxogDm77f8YnVXJL2VD3bbqowu5E3EMhBYA==}
@@ -12622,6 +13595,10 @@ packages:
   simple-wcswidth@1.1.2:
     resolution: {integrity: sha512-j7piyCjAeTDSjzTSQ7DokZtMNwNlEAyxqSZeCS+CXH7fJ4jx3FuJ/mTW3mE+6JLs4VJBbcll0Kjn+KXI5t21Iw==}
 
+  simple-xml-to-json@1.2.7:
+    resolution: {integrity: sha512-mz9VXphOxQWX3eQ/uXCtm6upltoN0DLx8Zb5T4TFC4FHB7S9FDPGre8CfLWqPWQQH/GrQYd2AXhhVM5LDpYx6Q==}
+    engines: {node: '>=20.12.2'}
+
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
@@ -12629,6 +13606,14 @@ packages:
     resolution: {integrity: sha512-S6hzjGJSG3d6if0YoF5kTyeRJvia6FSTBroE5fQ0bu1QNxyJqhhinfUsXi9fH3MgtXODWvwo2BDyQSnhPQ88uQ==}
     engines: {node: '>=20.19.5', npm: '>=10.8.2'}
     hasBin: true
+
+  skin-tone@2.0.0:
+    resolution: {integrity: sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==}
+    engines: {node: '>=8'}
+
+  slice-ansi@9.0.0:
+    resolution: {integrity: sha512-SO/3iYL5S3W57LLEniscOGPZgOqZUPCx6d3dB+52B80yJ0XstzsC/eV8gnA4tM3MHDrKz+OCFSLNjswdSC+/bA==}
+    engines: {node: '>=22'}
 
   smart-buffer@4.2.0:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
@@ -12689,6 +13674,10 @@ packages:
     resolution: {integrity: sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==}
     engines: {node: '>=10.16.0'}
 
+  stack-utils@2.0.6:
+    resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
+    engines: {node: '>=10'}
+
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
@@ -12701,6 +13690,10 @@ packages:
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  stdin-discarder@0.3.2:
+    resolution: {integrity: sha512-eCPu1qRxPVkl5605OTWF8Wz40b4Mf45NY5LQmVPQ599knfs5QhASUm9GbJ5BDMDOXgrnh0wyEdvzmL//YMlw0A==}
+    engines: {node: '>=18'}
 
   stream-browserify@3.0.0:
     resolution: {integrity: sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==}
@@ -12730,6 +13723,10 @@ packages:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
     engines: {node: '>=18'}
 
+  string-width@8.2.2:
+    resolution: {integrity: sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==}
+    engines: {node: '>=20'}
+
   string_decoder@1.1.1:
     resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
 
@@ -12754,6 +13751,10 @@ packages:
   strip-final-newline@3.0.0:
     resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
     engines: {node: '>=12'}
+
+  strip-final-newline@4.0.0:
+    resolution: {integrity: sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==}
+    engines: {node: '>=18'}
 
   strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
@@ -12791,6 +13792,10 @@ packages:
     engines: {node: '>=16 || 14 >=14.17'}
     hasBin: true
 
+  supports-color@10.2.2:
+    resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
+    engines: {node: '>=18'}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -12798,6 +13803,14 @@ packages:
   supports-color@8.1.1:
     resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
     engines: {node: '>=10'}
+
+  supports-hyperlinks@3.2.0:
+    resolution: {integrity: sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==}
+    engines: {node: '>=14.18'}
+
+  supports-hyperlinks@4.5.0:
+    resolution: {integrity: sha512-ZW2OvfeCXrNTbLakPUzjQG922EeGCOteFSVoek5DKStTh898wf7zgtuFlzQN8HfZCxC3Eh02yJVrRW51hADf+w==}
+    engines: {node: '>=20'}
 
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
@@ -12814,6 +13827,10 @@ packages:
 
   tabbable@6.5.0:
     resolution: {integrity: sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==}
+
+  tagged-tag@1.0.0:
+    resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
+    engines: {node: '>=20'}
 
   tailwind-merge@2.6.1:
     resolution: {integrity: sha512-Oo6tHdpZsGpkKG88HJ8RR1rg/RdnEkQEfMoEk2x1XRI3F1AxeU+ijRXpiVUF4UbLfcxxRGw6TbUINKYdWVsQTQ==}
@@ -12847,6 +13864,14 @@ packages:
   teex@1.0.1:
     resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
 
+  terminal-link@5.0.0:
+    resolution: {integrity: sha512-qFAy10MTMwjzjU8U16YS4YoZD+NQLHzLssFMNqgravjbvIPNiqkGFR4yjhJfmY9R5OFU7+yHxc6y+uGHkKwLRA==}
+    engines: {node: '>=20'}
+
+  terminal-size@4.0.1:
+    resolution: {integrity: sha512-avMLDQpUI9I5XFrklECw1ZEUPJhqzcwSWsyyI8blhRLT+8N1jLJWLWWYQpB2q2xthq8xDvjZPISVh53T/+CLYQ==}
+    engines: {node: '>=18'}
+
   text-decoder@1.2.7:
     resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
 
@@ -12875,6 +13900,9 @@ packages:
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinycolor2@1.6.0:
+    resolution: {integrity: sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==}
 
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
@@ -13014,9 +14042,17 @@ packages:
     resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
     engines: {node: '>=10'}
 
+  type-fest@2.19.0:
+    resolution: {integrity: sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==}
+    engines: {node: '>=12.20'}
+
   type-fest@4.41.0:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
     engines: {node: '>=16'}
+
+  type-fest@5.8.0:
+    resolution: {integrity: sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==}
+    engines: {node: '>=20'}
 
   type-is@2.0.1:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
@@ -13101,6 +14137,14 @@ packages:
 
   unenv@2.0.0-rc.24:
     resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
+
+  unicode-emoji-modifier-base@1.0.0:
+    resolution: {integrity: sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==}
+    engines: {node: '>=4'}
+
+  unicorn-magic@0.3.0:
+    resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
+    engines: {node: '>=18'}
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
@@ -13344,6 +14388,9 @@ packages:
     peerDependencies:
       react: ^16.8.0  || ^17 || ^18 || ^19 || ^19.0.0-rc
 
+  utif2@4.1.0:
+    resolution: {integrity: sha512-+oknB9FHrJ7oW7A2WZYajOcv4FcDR4CfoGB0dPNfxbi4GO05RRnFmt5oa23+9w32EanrYcSJWspUiJkLMs+37w==}
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
@@ -13365,6 +14412,10 @@ packages:
 
   uuid@12.0.1:
     resolution: {integrity: sha512-9obBF8sMIHJWNQaO6IGOG8giGa/jUpKX34bz6o4whVs8M0WAvhID2tNxYp6A2XEBJPuZSX8wsS/6TEKfIDc+nw==}
+    hasBin: true
+
+  uuid@14.0.1:
+    resolution: {integrity: sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==}
     hasBin: true
 
   uuid@9.0.1:
@@ -13580,8 +14631,16 @@ packages:
     resolution: {integrity: sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==}
     engines: {node: '>=18'}
 
+  widest-line@6.0.0:
+    resolution: {integrity: sha512-U89AsyEeAsyoF0zVJBkG9zBgekjgjK7yk9sje3F4IQpXBJ10TF6ByLlIfjMhcmHMJgHZI4KHt4rdNfktzxIAMA==}
+    engines: {node: '>=20'}
+
   wordwrap@1.0.0:
     resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
+
+  wrap-ansi@10.0.0:
+    resolution: {integrity: sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==}
+    engines: {node: '>=20'}
 
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
@@ -13633,6 +14692,17 @@ packages:
   xdg-portable@7.3.0:
     resolution: {integrity: sha512-sqMMuL1rc0FmMBOzCpd0yuy9trqF2yTTVe+E9ogwCSWQCdDEtQUwrZPT6AxqtsFGRNxycgncbP/xmOOSPw5ZUw==}
     engines: {node: '>= 6.0'}
+
+  xml-parse-from-string@1.0.1:
+    resolution: {integrity: sha512-ErcKwJTF54uRzzNMXq2X5sMIy88zJvfN2DmdoQvy7PAFJ+tPRU6ydWuOKNMyfmOjdyBQTFREi60s0Y0SyI0G0g==}
+
+  xml2js@0.5.0:
+    resolution: {integrity: sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==}
+    engines: {node: '>=4.0.0'}
+
+  xmlbuilder@11.0.1:
+    resolution: {integrity: sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==}
+    engines: {node: '>=4.0'}
 
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
@@ -13695,6 +14765,9 @@ packages:
   yoctocolors@2.1.2:
     resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
     engines: {node: '>=18'}
+
+  yoga-layout@3.2.1:
+    resolution: {integrity: sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==}
 
   z-schema@5.0.5:
     resolution: {integrity: sha512-D7eujBWkLa3p2sIpJA0d1pr7es+a7m0vFAnZLlCEKq/Ij2k0MLi9Br2UPxoxdYystm5K1yeBGzub0FlYUEWj2Q==}
@@ -13813,6 +14886,12 @@ snapshots:
       zod: 4.3.6
     optional: true
 
+  '@ai-sdk/anthropic@3.0.100(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.14
+      '@ai-sdk/provider-utils': 4.0.40(zod@4.3.6)
+      zod: 4.3.6
+
   '@ai-sdk/anthropic@3.0.64(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
@@ -13872,6 +14951,13 @@ snapshots:
       '@vercel/oidc': 3.1.0
       zod: 3.25.76
 
+  '@ai-sdk/gateway@3.0.83(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.21(zod@4.3.6)
+      '@vercel/oidc': 3.1.0
+      zod: 4.3.6
+
   '@ai-sdk/gateway@4.0.19(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 4.0.3
@@ -13920,6 +15006,12 @@ snapshots:
       zod: 4.3.6
     optional: true
 
+  '@ai-sdk/openai-compatible@2.0.62(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.14
+      '@ai-sdk/provider-utils': 4.0.40(zod@4.3.6)
+      zod: 4.3.6
+
   '@ai-sdk/openai@2.0.102(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 2.0.1
@@ -13933,6 +15025,12 @@ snapshots:
       '@ai-sdk/provider-utils': 3.0.28(zod@4.3.6)
       zod: 4.3.6
     optional: true
+
+  '@ai-sdk/openai@3.0.87(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.14
+      '@ai-sdk/provider-utils': 4.0.40(zod@4.3.6)
+      zod: 4.3.6
 
   '@ai-sdk/perplexity@2.0.27(zod@4.3.6)':
     dependencies:
@@ -13963,6 +15061,20 @@ snapshots:
       eventsource-parser: 3.0.6
       zod: 3.25.76
 
+  '@ai-sdk/provider-utils@4.0.21(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.6
+      zod: 4.3.6
+
+  '@ai-sdk/provider-utils@4.0.40(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.14
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.1.0
+      zod: 4.3.6
+
   '@ai-sdk/provider-utils@5.0.9(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 4.0.3
@@ -13976,6 +15088,10 @@ snapshots:
       json-schema: 0.4.0
 
   '@ai-sdk/provider@2.0.3':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/provider@3.0.14':
     dependencies:
       json-schema: 0.4.0
 
@@ -14002,6 +15118,11 @@ snapshots:
       '@ai-sdk/provider-utils': 3.0.23(zod@4.3.6)
       zod: 4.3.6
     optional: true
+
+  '@alcalzone/ansi-tokenize@0.3.0':
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 5.1.0
 
   '@alloc/quick-lru@5.2.0': {}
 
@@ -14138,12 +15259,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/mdx@4.3.14(astro@5.18.2(@types/node@24.13.2)(aws4fetch@1.0.20)(db0@0.3.4(better-sqlite3@12.8.0)(drizzle-orm@0.44.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)))(jiti@2.7.0)(rollup@4.60.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0))':
+  '@astrojs/mdx@4.3.14(astro@5.18.2(@types/node@24.13.2)(aws4fetch@1.0.20)(db0@0.3.4(better-sqlite3@12.8.0)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)))(jiti@2.7.0)(rollup@4.60.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0))':
     dependencies:
       '@astrojs/markdown-remark': 6.3.11
       '@mdx-js/mdx': 3.1.1
       acorn: 8.17.0
-      astro: 5.18.2(@types/node@24.13.2)(aws4fetch@1.0.20)(db0@0.3.4(better-sqlite3@12.8.0)(drizzle-orm@0.44.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)))(jiti@2.7.0)(rollup@4.60.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0)
+      astro: 5.18.2(@types/node@24.13.2)(aws4fetch@1.0.20)(db0@0.3.4(better-sqlite3@12.8.0)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)))(jiti@2.7.0)(rollup@4.60.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0)
       es-module-lexer: 1.7.0
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
@@ -14190,9 +15311,9 @@ snapshots:
       stream-replace-string: 2.0.0
       zod: 4.3.6
 
-  '@astrojs/tailwind@6.0.2(astro@5.18.2(@types/node@24.13.2)(aws4fetch@1.0.20)(db0@0.3.4(better-sqlite3@12.8.0)(drizzle-orm@0.44.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)))(jiti@2.7.0)(rollup@4.60.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.9.0))':
+  '@astrojs/tailwind@6.0.2(astro@5.18.2(@types/node@24.13.2)(aws4fetch@1.0.20)(db0@0.3.4(better-sqlite3@12.8.0)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)))(jiti@2.7.0)(rollup@4.60.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
-      astro: 5.18.2(@types/node@24.13.2)(aws4fetch@1.0.20)(db0@0.3.4(better-sqlite3@12.8.0)(drizzle-orm@0.44.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)))(jiti@2.7.0)(rollup@4.60.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0)
+      astro: 5.18.2(@types/node@24.13.2)(aws4fetch@1.0.20)(db0@0.3.4(better-sqlite3@12.8.0)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)))(jiti@2.7.0)(rollup@4.60.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0)
       autoprefixer: 10.5.0(postcss@8.5.8)
       postcss: 8.5.8
       postcss-load-config: 4.0.2(postcss@8.5.8)
@@ -15114,9 +16235,9 @@ snapshots:
 
   '@braintree/sanitize-url@7.1.2': {}
 
-  '@browserbasehq/browse-cli@0.5.0(@cfworker/json-schema@4.1.1)(@opentelemetry/api@1.9.0)(bufferutil@4.1.0)(deepmerge@4.3.1)(zod@4.3.6)':
+  '@browserbasehq/browse-cli@0.5.0(@cfworker/json-schema@4.1.1)(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(bufferutil@4.1.0)(deepmerge@4.3.1)(zod@4.3.6)':
     dependencies:
-      '@browserbasehq/stagehand': 3.2.0(@cfworker/json-schema@4.1.1)(@opentelemetry/api@1.9.0)(deepmerge@4.3.1)(zod@4.3.6)
+      '@browserbasehq/stagehand': 3.2.0(@cfworker/json-schema@4.1.1)(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(deepmerge@4.3.1)(zod@4.3.6)
       commander: 12.1.0
       dotenv: 16.6.1
       node-html-markdown: 1.3.0
@@ -15176,13 +16297,13 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@browserbasehq/stagehand@3.2.0(@cfworker/json-schema@4.1.1)(@opentelemetry/api@1.9.0)(deepmerge@4.3.1)(zod@4.3.6)':
+  '@browserbasehq/stagehand@3.2.0(@cfworker/json-schema@4.1.1)(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(deepmerge@4.3.1)(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 2.0.3
       '@anthropic-ai/sdk': 0.39.0
       '@browserbasehq/sdk': 2.10.0
       '@google/genai': 1.47.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(bufferutil@4.1.0)
-      '@langchain/openai': 0.4.9(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0(bufferutil@4.1.0))(zod@4.3.6)))(ws@8.21.0(bufferutil@4.1.0))
+      '@langchain/openai': 0.4.9(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.21.0(bufferutil@4.1.0))(zod@4.3.6)))(ws@8.21.0(bufferutil@4.1.0))
       '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       ai: 5.0.172(zod@4.3.6)
       deepmerge: 4.3.1
@@ -15209,7 +16330,7 @@ snapshots:
       '@ai-sdk/perplexity': 2.0.27(zod@4.3.6)
       '@ai-sdk/togetherai': 1.0.38(zod@4.3.6)
       '@ai-sdk/xai': 2.0.67(zod@4.3.6)
-      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0(bufferutil@4.1.0))(zod@4.3.6))
+      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.21.0(bufferutil@4.1.0))(zod@4.3.6))
       bufferutil: 4.1.0
       chrome-launcher: 1.2.1
       ollama-ai-provider-v2: 1.5.5(zod@4.3.6)
@@ -15297,6 +16418,18 @@ snapshots:
 
   '@chevrotain/types@11.1.2': {}
 
+  '@clack/core@1.4.3':
+    dependencies:
+      fast-wrap-ansi: 0.2.2
+      sisteransi: 1.0.5
+
+  '@clack/prompts@1.7.0':
+    dependencies:
+      '@clack/core': 1.4.3
+      fast-string-width: 3.0.2
+      fast-wrap-ansi: 0.2.2
+      sisteransi: 1.0.5
+
   '@codemirror/autocomplete@6.20.3':
     dependencies:
       '@codemirror/language': 6.12.4
@@ -15365,7 +16498,45 @@ snapshots:
       style-mod: 4.1.3
       w3c-keyname: 2.2.8
 
+  '@colors/colors@1.5.0':
+    optional: true
+
   '@copilotkit/llmock@1.6.0': {}
+
+  '@crosscopy/clipboard-darwin-arm64@0.2.8':
+    optional: true
+
+  '@crosscopy/clipboard-darwin-universal@0.2.8':
+    optional: true
+
+  '@crosscopy/clipboard-darwin-x64@0.2.8':
+    optional: true
+
+  '@crosscopy/clipboard-linux-arm64-gnu@0.2.8':
+    optional: true
+
+  '@crosscopy/clipboard-linux-riscv64-gnu@0.2.8':
+    optional: true
+
+  '@crosscopy/clipboard-linux-x64-gnu@0.2.8':
+    optional: true
+
+  '@crosscopy/clipboard-win32-arm64-msvc@0.2.8':
+    optional: true
+
+  '@crosscopy/clipboard-win32-x64-msvc@0.2.8':
+    optional: true
+
+  '@crosscopy/clipboard@0.2.8':
+    optionalDependencies:
+      '@crosscopy/clipboard-darwin-arm64': 0.2.8
+      '@crosscopy/clipboard-darwin-universal': 0.2.8
+      '@crosscopy/clipboard-darwin-x64': 0.2.8
+      '@crosscopy/clipboard-linux-arm64-gnu': 0.2.8
+      '@crosscopy/clipboard-linux-riscv64-gnu': 0.2.8
+      '@crosscopy/clipboard-linux-x64-gnu': 0.2.8
+      '@crosscopy/clipboard-win32-arm64-msvc': 0.2.8
+      '@crosscopy/clipboard-win32-x64-msvc': 0.2.8
 
   '@earendil-works/pi-agent-core@0.80.10(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(bufferutil@4.1.0)(ws@8.21.0(bufferutil@4.1.0))(zod@3.25.76)':
     dependencies:
@@ -16069,6 +17240,229 @@ snapshots:
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
 
+  '@jimp/core@1.6.1':
+    dependencies:
+      '@jimp/file-ops': 1.6.1
+      '@jimp/types': 1.6.1
+      '@jimp/utils': 1.6.1
+      await-to-js: 3.0.0
+      exif-parser: 0.1.12
+      file-type: 21.3.4
+      mime: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jimp/diff@1.6.1':
+    dependencies:
+      '@jimp/plugin-resize': 1.6.1
+      '@jimp/types': 1.6.1
+      '@jimp/utils': 1.6.1
+      pixelmatch: 5.3.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jimp/file-ops@1.6.1': {}
+
+  '@jimp/js-bmp@1.6.1':
+    dependencies:
+      '@jimp/core': 1.6.1
+      '@jimp/types': 1.6.1
+      '@jimp/utils': 1.6.1
+      bmp-ts: 1.0.9
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jimp/js-gif@1.6.1':
+    dependencies:
+      '@jimp/core': 1.6.1
+      '@jimp/types': 1.6.1
+      gifwrap: 0.10.1
+      omggif: 1.0.10
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jimp/js-jpeg@1.6.1':
+    dependencies:
+      '@jimp/core': 1.6.1
+      '@jimp/types': 1.6.1
+      jpeg-js: 0.4.4
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jimp/js-png@1.6.1':
+    dependencies:
+      '@jimp/core': 1.6.1
+      '@jimp/types': 1.6.1
+      pngjs: 7.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jimp/js-tiff@1.6.1':
+    dependencies:
+      '@jimp/core': 1.6.1
+      '@jimp/types': 1.6.1
+      utif2: 4.1.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jimp/plugin-blit@1.6.1':
+    dependencies:
+      '@jimp/types': 1.6.1
+      '@jimp/utils': 1.6.1
+      zod: 3.25.76
+
+  '@jimp/plugin-blur@1.6.1':
+    dependencies:
+      '@jimp/core': 1.6.1
+      '@jimp/utils': 1.6.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jimp/plugin-circle@1.6.1':
+    dependencies:
+      '@jimp/types': 1.6.1
+      zod: 3.25.76
+
+  '@jimp/plugin-color@1.6.1':
+    dependencies:
+      '@jimp/core': 1.6.1
+      '@jimp/types': 1.6.1
+      '@jimp/utils': 1.6.1
+      tinycolor2: 1.6.0
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jimp/plugin-contain@1.6.1':
+    dependencies:
+      '@jimp/core': 1.6.1
+      '@jimp/plugin-blit': 1.6.1
+      '@jimp/plugin-resize': 1.6.1
+      '@jimp/types': 1.6.1
+      '@jimp/utils': 1.6.1
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jimp/plugin-cover@1.6.1':
+    dependencies:
+      '@jimp/core': 1.6.1
+      '@jimp/plugin-crop': 1.6.1
+      '@jimp/plugin-resize': 1.6.1
+      '@jimp/types': 1.6.1
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jimp/plugin-crop@1.6.1':
+    dependencies:
+      '@jimp/core': 1.6.1
+      '@jimp/types': 1.6.1
+      '@jimp/utils': 1.6.1
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jimp/plugin-displace@1.6.1':
+    dependencies:
+      '@jimp/types': 1.6.1
+      '@jimp/utils': 1.6.1
+      zod: 3.25.76
+
+  '@jimp/plugin-dither@1.6.1':
+    dependencies:
+      '@jimp/types': 1.6.1
+
+  '@jimp/plugin-fisheye@1.6.1':
+    dependencies:
+      '@jimp/types': 1.6.1
+      '@jimp/utils': 1.6.1
+      zod: 3.25.76
+
+  '@jimp/plugin-flip@1.6.1':
+    dependencies:
+      '@jimp/types': 1.6.1
+      zod: 3.25.76
+
+  '@jimp/plugin-hash@1.6.1':
+    dependencies:
+      '@jimp/core': 1.6.1
+      '@jimp/js-bmp': 1.6.1
+      '@jimp/js-jpeg': 1.6.1
+      '@jimp/js-png': 1.6.1
+      '@jimp/js-tiff': 1.6.1
+      '@jimp/plugin-color': 1.6.1
+      '@jimp/plugin-resize': 1.6.1
+      '@jimp/types': 1.6.1
+      '@jimp/utils': 1.6.1
+      any-base: 1.1.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jimp/plugin-mask@1.6.1':
+    dependencies:
+      '@jimp/types': 1.6.1
+      zod: 3.25.76
+
+  '@jimp/plugin-print@1.6.1':
+    dependencies:
+      '@jimp/core': 1.6.1
+      '@jimp/js-jpeg': 1.6.1
+      '@jimp/js-png': 1.6.1
+      '@jimp/plugin-blit': 1.6.1
+      '@jimp/types': 1.6.1
+      parse-bmfont-ascii: 1.0.6
+      parse-bmfont-binary: 1.0.6
+      parse-bmfont-xml: 1.1.6
+      simple-xml-to-json: 1.2.7
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jimp/plugin-quantize@1.6.1':
+    dependencies:
+      image-q: 4.0.0
+      zod: 3.25.76
+
+  '@jimp/plugin-resize@1.6.1':
+    dependencies:
+      '@jimp/core': 1.6.1
+      '@jimp/types': 1.6.1
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jimp/plugin-rotate@1.6.1':
+    dependencies:
+      '@jimp/core': 1.6.1
+      '@jimp/plugin-crop': 1.6.1
+      '@jimp/plugin-resize': 1.6.1
+      '@jimp/types': 1.6.1
+      '@jimp/utils': 1.6.1
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jimp/plugin-threshold@1.6.1':
+    dependencies:
+      '@jimp/core': 1.6.1
+      '@jimp/plugin-color': 1.6.1
+      '@jimp/plugin-hash': 1.6.1
+      '@jimp/types': 1.6.1
+      '@jimp/utils': 1.6.1
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jimp/types@1.6.1':
+    dependencies:
+      zod: 3.25.76
+
+  '@jimp/utils@1.6.1':
+    dependencies:
+      '@jimp/types': 1.6.1
+      tinycolor2: 1.6.0
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -16090,14 +17484,14 @@ snapshots:
 
   '@js-sdsl/ordered-map@4.4.2': {}
 
-  '@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0(bufferutil@4.1.0))(zod@4.3.6))':
+  '@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.21.0(bufferutil@4.1.0))(zod@4.3.6))':
     dependencies:
       '@cfworker/json-schema': 4.1.1
       ansi-styles: 5.2.0
       camelcase: 6.3.0
       decamelize: 1.2.0
       js-tiktoken: 1.0.21
-      langsmith: 0.3.87(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0(bufferutil@4.1.0))(zod@4.3.6))
+      langsmith: 0.3.87(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.21.0(bufferutil@4.1.0))(zod@4.3.6))
       mustache: 4.2.0
       p-queue: 6.6.2
       p-retry: 4.6.2
@@ -16110,9 +17504,9 @@ snapshots:
       - '@opentelemetry/sdk-trace-base'
       - openai
 
-  '@langchain/openai@0.4.9(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0(bufferutil@4.1.0))(zod@4.3.6)))(ws@8.21.0(bufferutil@4.1.0))':
+  '@langchain/openai@0.4.9(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.21.0(bufferutil@4.1.0))(zod@4.3.6)))(ws@8.21.0(bufferutil@4.1.0))':
     dependencies:
-      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0(bufferutil@4.1.0))(zod@4.3.6))
+      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.21.0(bufferutil@4.1.0))(zod@4.3.6))
       js-tiktoken: 1.0.21
       openai: 4.104.0(ws@8.21.0(bufferutil@4.1.0))(zod@3.25.76)
       zod: 3.25.76
@@ -16350,6 +17744,17 @@ snapshots:
     dependencies:
       '@chevrotain/types': 11.1.2
 
+  '@microlabs/otel-cf-workers@1.0.0-rc.52(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-trace-otlp-http': 0.200.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.200.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.200.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.10.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
   '@microsoft/api-extractor-model@7.28.13(@types/node@20.19.43)':
     dependencies:
       '@microsoft/tsdoc': 0.14.2
@@ -16553,7 +17958,338 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.6
 
+  '@opentelemetry/api-logs@0.200.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+
+  '@opentelemetry/api-logs@0.218.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+
   '@opentelemetry/api@1.9.0': {}
+
+  '@opentelemetry/configuration@0.218.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
+      yaml: 2.9.0
+
+  '@opentelemetry/context-async-hooks@2.10.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+
+  '@opentelemetry/context-async-hooks@2.7.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+
+  '@opentelemetry/core@2.0.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/exporter-logs-otlp-grpc@0.218.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@grpc/grpc-js': 1.14.3
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.218.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-grpc-exporter-base': 0.218.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.218.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs': 0.218.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/exporter-logs-otlp-http@0.218.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.218.0
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.218.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.218.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs': 0.218.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/exporter-logs-otlp-proto@0.218.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.218.0
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.218.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.218.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs': 0.218.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/exporter-metrics-otlp-grpc@0.218.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@grpc/grpc-js': 1.14.3
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-metrics-otlp-http': 0.218.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.218.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-grpc-exporter-base': 0.218.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.218.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/exporter-metrics-otlp-http@0.218.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.218.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.218.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/exporter-metrics-otlp-proto@0.218.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-metrics-otlp-http': 0.218.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.218.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.218.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/exporter-prometheus@0.218.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/exporter-trace-otlp-grpc@0.218.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@grpc/grpc-js': 1.14.3
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.218.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-grpc-exporter-base': 0.218.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.218.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/exporter-trace-otlp-http@0.200.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.0.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.200.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.200.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.0.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.0.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/exporter-trace-otlp-http@0.218.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.218.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.218.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.218.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.218.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/exporter-zipkin@2.7.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/instrumentation@0.218.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.218.0
+      import-in-the-middle: 3.3.2
+      require-in-the-middle: 8.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/otlp-exporter-base@0.200.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.0.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.200.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/otlp-exporter-base@0.218.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.218.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/otlp-grpc-exporter-base@0.218.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@grpc/grpc-js': 1.14.3
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.218.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.218.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/otlp-transformer@0.200.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.200.0
+      '@opentelemetry/core': 2.0.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.0.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs': 0.200.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-metrics': 2.0.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.0.0(@opentelemetry/api@1.9.0)
+      protobufjs: 7.5.4
+
+  '@opentelemetry/otlp-transformer@0.218.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.218.0
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs': 0.218.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/propagator-b3@2.7.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/propagator-jaeger@2.7.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/resources@2.0.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.0.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/resources@2.10.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/sdk-logs@0.200.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.200.0
+      '@opentelemetry/core': 2.0.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.0.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/sdk-logs@0.218.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.218.0
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/sdk-metrics@2.0.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.0.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.0.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/sdk-metrics@2.7.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/sdk-node@0.218.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.218.0
+      '@opentelemetry/configuration': 0.218.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/context-async-hooks': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-logs-otlp-grpc': 0.218.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-logs-otlp-http': 0.218.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-logs-otlp-proto': 0.218.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-metrics-otlp-grpc': 0.218.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-metrics-otlp-http': 0.218.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-metrics-otlp-proto': 0.218.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-prometheus': 0.218.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-trace-otlp-grpc': 0.218.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-trace-otlp-http': 0.218.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-trace-otlp-proto': 0.218.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-zipkin': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.218.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.218.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/propagator-b3': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/propagator-jaeger': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs': 0.218.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-node': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.43.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/sdk-trace-base@2.0.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.0.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.0.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace': 2.10.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/sdk-trace-node@2.10.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/context-async-hooks': 2.10.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.10.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/sdk-trace-node@2.7.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/context-async-hooks': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/sdk-trace@2.10.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.43.0
 
   '@opentelemetry/semantic-conventions@1.43.0': {}
 
@@ -17911,12 +19647,12 @@ snapshots:
     optionalDependencies:
       pyodide: 0.28.3(bufferutil@4.1.0)
 
-  '@rivet-dev/vercel-world@2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.21.0(bufferutil@4.1.0))':
+  '@rivet-dev/vercel-world@2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)(ws@8.21.0(bufferutil@4.1.0))':
     dependencies:
       '@workflow/errors': 5.0.0-beta.11
       '@workflow/world': 5.0.0-beta.21
       cbor-x: 1.6.4
-      rivetkit: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+      rivetkit: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       ulid: 3.0.2
     transitivePeerDependencies:
       - '@aws-sdk/client-rds-data'
@@ -18084,11 +19820,11 @@ snapshots:
     dependencies:
       '@rivetkit/bare-ts': 0.6.2
 
-  '@rivetkit/framework-base@2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))':
+  '@rivetkit/framework-base@2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))':
     dependencies:
       '@tanstack/store': 0.7.7
       fast-deep-equal: 3.1.3
-      rivetkit: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+      rivetkit: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
     transitivePeerDependencies:
       - '@aws-sdk/client-rds-data'
       - '@cloudflare/workers-types'
@@ -18126,13 +19862,13 @@ snapshots:
 
   '@rivetkit/on-change@6.0.1': {}
 
-  '@rivetkit/react@2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(ws@8.21.0(bufferutil@4.1.0))':
+  '@rivetkit/react@2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)(pyodide@0.28.3(bufferutil@4.1.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(ws@8.21.0(bufferutil@4.1.0))':
     dependencies:
-      '@rivetkit/framework-base': 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+      '@rivetkit/framework-base': 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       '@tanstack/react-store': 0.7.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      rivetkit: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+      rivetkit: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
     transitivePeerDependencies:
       - '@aws-sdk/client-rds-data'
       - '@cloudflare/workers-types'
@@ -18447,6 +20183,8 @@ snapshots:
       '@sandbox-agent/cli-win32-x64': 0.4.2
     optional: true
 
+  '@sec-ant/readable-stream@0.4.1': {}
+
   '@secure-exec/core@0.2.1':
     dependencies:
       better-sqlite3: 12.8.0
@@ -18560,9 +20298,22 @@ snapshots:
 
   '@sinclair/typebox@0.34.49': {}
 
+  '@sindresorhus/is@4.6.0': {}
+
+  '@sindresorhus/merge-streams@4.0.0': {}
+
+  '@sindresorhus/slugify@2.2.1':
+    dependencies:
+      '@sindresorhus/transliterate': 1.6.0
+      escape-string-regexp: 5.0.0
+
   '@sindresorhus/slugify@3.0.0':
     dependencies:
       '@sindresorhus/transliterate': 2.3.1
+      escape-string-regexp: 5.0.0
+
+  '@sindresorhus/transliterate@1.6.0':
+    dependencies:
       escape-string-regexp: 5.0.0
 
   '@sindresorhus/transliterate@2.3.1': {}
@@ -19200,6 +20951,8 @@ snapshots:
       '@types/node': 22.19.15
       form-data: 4.0.5
 
+  '@types/node@16.9.1': {}
+
   '@types/node@18.19.130':
     dependencies:
       undici-types: 5.26.5
@@ -19320,12 +21073,12 @@ snapshots:
     dependencies:
       execa: 5.1.1
 
-  '@vercel/connect@0.4.0(ai@7.0.26(zod@4.3.6))(eve@0.27.0(@opentelemetry/api@1.9.0)(ai@7.0.26(zod@4.3.6))(aws4fetch@1.0.20)(better-sqlite3@12.8.0)(chokidar@5.0.0)(dotenv@16.6.1)(drizzle-orm@0.44.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0))(jiti@2.7.0)(lru-cache@11.2.7))':
+  '@vercel/connect@0.4.0(ai@7.0.26(zod@4.3.6))(eve@0.27.0(@opentelemetry/api@1.9.0)(ai@7.0.26(zod@4.3.6))(aws4fetch@1.0.20)(better-sqlite3@12.8.0)(chokidar@5.0.0)(dotenv@17.4.2)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9))(giget@3.3.0)(jiti@2.7.0)(lru-cache@11.2.7))':
     dependencies:
       '@vercel/oidc': 3.8.0
     optionalDependencies:
       ai: 7.0.26(zod@4.3.6)
-      eve: 0.27.0(@opentelemetry/api@1.9.0)(ai@7.0.26(zod@4.3.6))(aws4fetch@1.0.20)(better-sqlite3@12.8.0)(chokidar@5.0.0)(dotenv@16.6.1)(drizzle-orm@0.44.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0))(jiti@2.7.0)(lru-cache@11.2.7)
+      eve: 0.27.0(@opentelemetry/api@1.9.0)(ai@7.0.26(zod@4.3.6))(aws4fetch@1.0.20)(better-sqlite3@12.8.0)(chokidar@5.0.0)(dotenv@17.4.2)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9))(giget@3.3.0)(jiti@2.7.0)(lru-cache@11.2.7)
 
   '@vercel/detect-agent@1.2.3': {}
 
@@ -19454,6 +21207,58 @@ snapshots:
       '@volar/language-core': 1.11.1
       path-browserify: 1.0.1
 
+  '@vscode/ripgrep-darwin-arm64@1.18.0':
+    optional: true
+
+  '@vscode/ripgrep-darwin-x64@1.18.0':
+    optional: true
+
+  '@vscode/ripgrep-linux-arm64@1.18.0':
+    optional: true
+
+  '@vscode/ripgrep-linux-arm@1.18.0':
+    optional: true
+
+  '@vscode/ripgrep-linux-ia32@1.18.0':
+    optional: true
+
+  '@vscode/ripgrep-linux-ppc64@1.18.0':
+    optional: true
+
+  '@vscode/ripgrep-linux-riscv64@1.18.0':
+    optional: true
+
+  '@vscode/ripgrep-linux-s390x@1.18.0':
+    optional: true
+
+  '@vscode/ripgrep-linux-x64@1.18.0':
+    optional: true
+
+  '@vscode/ripgrep-win32-arm64@1.18.0':
+    optional: true
+
+  '@vscode/ripgrep-win32-ia32@1.18.0':
+    optional: true
+
+  '@vscode/ripgrep-win32-x64@1.18.0':
+    optional: true
+
+  '@vscode/ripgrep@1.18.0':
+    optionalDependencies:
+      '@vscode/ripgrep-darwin-arm64': 1.18.0
+      '@vscode/ripgrep-darwin-x64': 1.18.0
+      '@vscode/ripgrep-linux-arm': 1.18.0
+      '@vscode/ripgrep-linux-arm64': 1.18.0
+      '@vscode/ripgrep-linux-ia32': 1.18.0
+      '@vscode/ripgrep-linux-ppc64': 1.18.0
+      '@vscode/ripgrep-linux-riscv64': 1.18.0
+      '@vscode/ripgrep-linux-s390x': 1.18.0
+      '@vscode/ripgrep-linux-x64': 1.18.0
+      '@vscode/ripgrep-win32-arm64': 1.18.0
+      '@vscode/ripgrep-win32-ia32': 1.18.0
+      '@vscode/ripgrep-win32-x64': 1.18.0
+    optional: true
+
   '@vue/compiler-core@3.5.40':
     dependencies:
       '@babel/parser': 7.29.7
@@ -19565,6 +21370,14 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       zod: 3.25.76
 
+  ai@6.0.141(zod@4.3.6):
+    dependencies:
+      '@ai-sdk/gateway': 3.0.83(zod@4.3.6)
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.21(zod@4.3.6)
+      '@opentelemetry/api': 1.9.0
+      zod: 4.3.6
+
   ai@7.0.26(zod@4.3.6):
     dependencies:
       '@ai-sdk/gateway': 4.0.19(zod@4.3.6)
@@ -19598,6 +21411,10 @@ snapshots:
     dependencies:
       type-fest: 0.21.3
 
+  ansi-escapes@7.3.0:
+    dependencies:
+      environment: 1.1.0
+
   ansi-regex@5.0.1: {}
 
   ansi-regex@6.2.2: {}
@@ -19611,6 +21428,8 @@ snapshots:
   ansi-styles@6.2.3: {}
 
   ansis@3.17.0: {}
+
+  any-base@1.1.0: {}
 
   any-promise@1.3.0: {}
 
@@ -19685,7 +21504,7 @@ snapshots:
 
   astring@1.9.0: {}
 
-  astro@5.18.2(@types/node@24.13.2)(aws4fetch@1.0.20)(db0@0.3.4(better-sqlite3@12.8.0)(drizzle-orm@0.44.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)))(jiti@2.7.0)(rollup@4.60.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0):
+  astro@5.18.2(@types/node@24.13.2)(aws4fetch@1.0.20)(db0@0.3.4(better-sqlite3@12.8.0)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)))(jiti@2.7.0)(rollup@4.60.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0):
     dependencies:
       '@astrojs/compiler': 2.13.1
       '@astrojs/internal-helpers': 0.7.6
@@ -19740,7 +21559,7 @@ snapshots:
       ultrahtml: 1.7.0
       unifont: 0.7.4
       unist-util-visit: 5.1.0
-      unstorage: 1.17.5(aws4fetch@1.0.20)(db0@0.3.4(better-sqlite3@12.8.0)(drizzle-orm@0.44.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)))
+      unstorage: 1.17.5(aws4fetch@1.0.20)(db0@0.3.4(better-sqlite3@12.8.0)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)))
       vfile: 6.0.3
       vite: 6.4.3(@types/node@24.13.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
       vitefu: 1.1.3(vite@6.4.3(@types/node@24.13.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
@@ -19798,6 +21617,8 @@ snapshots:
 
   atomic-sleep@1.0.0: {}
 
+  auto-bind@5.0.1: {}
+
   autoprefixer@10.5.0(postcss@8.5.8):
     dependencies:
       browserslist: 4.28.2
@@ -19810,6 +21631,8 @@ snapshots:
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
+
+  await-to-js@3.0.0: {}
 
   aws4fetch@1.0.20:
     optional: true
@@ -19896,6 +21719,8 @@ snapshots:
       buffer: 5.7.1
       inherits: 2.0.4
       readable-stream: 3.6.2
+
+  bmp-ts@1.0.9: {}
 
   bn.js@4.12.4: {}
 
@@ -20149,6 +21974,8 @@ snapshots:
 
   chalk@5.6.2: {}
 
+  char-regex@1.0.2: {}
+
   character-entities-html4@2.1.0: {}
 
   character-entities-legacy@3.0.0: {}
@@ -20219,6 +22046,16 @@ snapshots:
 
   cli-boxes@3.0.0: {}
 
+  cli-boxes@4.0.1: {}
+
+  cli-cursor@4.0.0:
+    dependencies:
+      restore-cursor: 4.0.0
+
+  cli-cursor@5.0.0:
+    dependencies:
+      restore-cursor: 5.1.0
+
   cli-highlight@2.1.11:
     dependencies:
       chalk: 4.1.2
@@ -20229,6 +22066,19 @@ snapshots:
       yargs: 16.2.0
 
   cli-spinners@2.9.2: {}
+
+  cli-spinners@3.4.0: {}
+
+  cli-table3@0.6.5:
+    dependencies:
+      string-width: 4.2.3
+    optionalDependencies:
+      '@colors/colors': 1.5.0
+
+  cli-truncate@6.1.1:
+    dependencies:
+      slice-ansi: 9.0.0
+      string-width: 8.2.2
 
   cliui@7.0.4:
     dependencies:
@@ -20268,6 +22118,10 @@ snapshots:
       - '@types/react'
       - '@types/react-dom'
 
+  code-excerpt@4.0.0:
+    dependencies:
+      convert-to-spaces: 2.0.1
+
   codemirror@6.0.2:
     dependencies:
       '@codemirror/autocomplete': 6.20.3
@@ -20303,6 +22157,94 @@ snapshots:
       delayed-stream: 1.0.0
 
   comma-separated-tokens@2.0.3: {}
+
+  command-code@1.1.0(@types/react@19.2.17)(better-sqlite3@12.8.0)(bufferutil@4.1.0):
+    dependencies:
+      '@ai-sdk/anthropic': 3.0.100(zod@4.3.6)
+      '@ai-sdk/openai': 3.0.87(zod@4.3.6)
+      '@ai-sdk/openai-compatible': 2.0.62(zod@4.3.6)
+      '@ai-sdk/provider': 3.0.8
+      '@clack/prompts': 1.7.0
+      '@crosscopy/clipboard': 0.2.8
+      '@microlabs/otel-cf-workers': 1.0.0-rc.52(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/exporter-trace-otlp-http': 0.218.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-node': 0.218.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-node': 2.10.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.43.0
+      '@sindresorhus/slugify': 2.2.1
+      ai: 6.0.141(zod@4.3.6)
+      ansi-escapes: 7.3.0
+      chalk: 5.6.2
+      commander: 14.0.3
+      dedent: 1.7.2
+      diff: 8.0.4
+      dotenv: 17.4.2
+      drizzle-orm: 0.45.2(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)
+      fast-wrap-ansi: 0.2.2
+      figures: 6.1.0
+      giget: 3.3.0
+      glob: 13.0.6
+      ignore: 7.0.5
+      ink: 7.1.0(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)
+      ink-spinner: 5.0.0(ink@7.1.0(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7))(react@19.2.7)
+      is-unicode-supported: 2.1.0
+      jimp: 1.6.1
+      jiti: 2.7.0
+      js-yaml: 4.3.0
+      log-symbols: 7.0.1
+      marked: 15.0.12
+      marked-terminal: 7.3.0(marked@15.0.12)
+      open: 10.2.0
+      open-editor: 5.1.0
+      ora: 9.4.1
+      picocolors: 1.1.1
+      postgres: 3.4.9
+      react: 19.2.7
+      semver: 7.8.5
+      shell-quote: 1.8.4
+      string-width: 8.2.2
+      strip-ansi: 7.2.0
+      terminal-link: 5.0.0
+      uuid: 14.0.1
+      zod: 4.3.6
+    optionalDependencies:
+      '@vscode/ripgrep': 1.18.0
+    transitivePeerDependencies:
+      - '@aws-sdk/client-rds-data'
+      - '@cloudflare/workers-types'
+      - '@electric-sql/pglite'
+      - '@libsql/client'
+      - '@libsql/client-wasm'
+      - '@neondatabase/serverless'
+      - '@op-engineering/op-sqlite'
+      - '@planetscale/database'
+      - '@prisma/client'
+      - '@tidbcloud/serverless'
+      - '@types/better-sqlite3'
+      - '@types/pg'
+      - '@types/react'
+      - '@types/sql.js'
+      - '@upstash/redis'
+      - '@vercel/postgres'
+      - '@xata.io/client'
+      - babel-plugin-macros
+      - better-sqlite3
+      - bufferutil
+      - bun-types
+      - expo-sqlite
+      - gel
+      - knex
+      - kysely
+      - mysql2
+      - pg
+      - prisma
+      - react-devtools-core
+      - sql.js
+      - sqlite3
+      - supports-color
+      - utf-8-validate
 
   commander@11.1.0: {}
 
@@ -20359,6 +22301,8 @@ snapshots:
   content-type@1.0.5: {}
 
   convert-source-map@2.0.0: {}
+
+  convert-to-spaces@2.0.1: {}
 
   cookie-es@1.2.3: {}
 
@@ -20677,10 +22621,10 @@ snapshots:
 
   dayjs@1.11.21: {}
 
-  db0@0.3.4(better-sqlite3@12.8.0)(drizzle-orm@0.44.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)):
+  db0@0.3.4(better-sqlite3@12.8.0)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)):
     optionalDependencies:
       better-sqlite3: 12.8.0
-      drizzle-orm: 0.44.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)
+      drizzle-orm: 0.45.2(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)
 
   de-indent@1.0.2: {}
 
@@ -20841,10 +22785,19 @@ snapshots:
 
   dotenv@16.6.1: {}
 
-  drizzle-orm@0.44.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0):
+  dotenv@17.4.2: {}
+
+  drizzle-orm@0.44.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9):
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
       better-sqlite3: 12.8.0
+      postgres: 3.4.9
+
+  drizzle-orm@0.45.2(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9):
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      better-sqlite3: 12.8.0
+      postgres: 3.4.9
 
   dset@3.1.4: {}
 
@@ -20884,6 +22837,8 @@ snapshots:
 
   emoji-regex@9.2.2: {}
 
+  emojilib@2.4.0: {}
+
   encodeurl@2.0.0: {}
 
   end-of-stream@1.4.5:
@@ -20896,6 +22851,8 @@ snapshots:
 
   entities@7.0.1: {}
 
+  env-editor@1.3.0: {}
+
   env-runner@0.1.16:
     dependencies:
       crossws: 0.4.10(srvx@0.11.22)
@@ -20903,11 +22860,15 @@ snapshots:
       httpxy: 0.5.5
       srvx: 0.11.22
 
+  environment@1.1.0: {}
+
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
 
   es-module-lexer@1.7.0: {}
+
+  es-module-lexer@2.3.1: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -21024,6 +22985,8 @@ snapshots:
 
   escape-html@1.0.3: {}
 
+  escape-string-regexp@2.0.0: {}
+
   escape-string-regexp@4.0.0: {}
 
   escape-string-regexp@5.0.0: {}
@@ -21084,10 +23047,10 @@ snapshots:
 
   etag@1.8.1: {}
 
-  eve@0.27.0(@opentelemetry/api@1.9.0)(ai@7.0.26(zod@4.3.6))(aws4fetch@1.0.20)(better-sqlite3@12.8.0)(chokidar@5.0.0)(dotenv@16.6.1)(drizzle-orm@0.44.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0))(jiti@2.7.0)(lru-cache@11.2.7):
+  eve@0.27.0(@opentelemetry/api@1.9.0)(ai@7.0.26(zod@4.3.6))(aws4fetch@1.0.20)(better-sqlite3@12.8.0)(chokidar@5.0.0)(dotenv@17.4.2)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9))(giget@3.3.0)(jiti@2.7.0)(lru-cache@11.2.7):
     dependencies:
       ai: 7.0.26(zod@4.3.6)
-      nitro: 3.0.260610-beta(aws4fetch@1.0.20)(better-sqlite3@12.8.0)(chokidar@5.0.0)(dotenv@16.6.1)(drizzle-orm@0.44.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0))(jiti@2.7.0)(lru-cache@11.2.7)
+      nitro: 3.0.260610-beta(aws4fetch@1.0.20)(better-sqlite3@12.8.0)(chokidar@5.0.0)(dotenv@17.4.2)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9))(giget@3.3.0)(jiti@2.7.0)(lru-cache@11.2.7)
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
     transitivePeerDependencies:
@@ -21181,6 +23144,23 @@ snapshots:
       signal-exit: 4.1.0
       strip-final-newline: 3.0.0
 
+  execa@9.6.1:
+    dependencies:
+      '@sindresorhus/merge-streams': 4.0.0
+      cross-spawn: 7.0.6
+      figures: 6.1.0
+      get-stream: 9.0.1
+      human-signals: 8.0.1
+      is-plain-obj: 4.1.0
+      is-stream: 4.0.1
+      npm-run-path: 6.0.0
+      pretty-ms: 9.3.0
+      signal-exit: 4.1.0
+      strip-final-newline: 4.0.0
+      yoctocolors: 2.1.2
+
+  exif-parser@0.1.12: {}
+
   expand-template@2.0.3: {}
 
   expect-type@1.3.0: {}
@@ -21259,7 +23239,17 @@ snapshots:
 
   fast-sha256@1.3.0: {}
 
+  fast-string-truncated-width@3.0.3: {}
+
+  fast-string-width@3.0.2:
+    dependencies:
+      fast-string-truncated-width: 3.0.3
+
   fast-uri@3.1.0: {}
+
+  fast-wrap-ansi@0.2.2:
+    dependencies:
+      fast-string-width: 3.0.2
 
   fast-xml-builder@1.1.4:
     dependencies:
@@ -21298,6 +23288,10 @@ snapshots:
       tough-cookie: 6.0.1
 
   fflate@0.4.9: {}
+
+  figures@6.1.0:
+    dependencies:
+      is-unicode-supported: 2.1.0
 
   file-type@21.3.4:
     dependencies:
@@ -21500,6 +23494,11 @@ snapshots:
 
   get-stream@8.0.1: {}
 
+  get-stream@9.0.1:
+    dependencies:
+      '@sec-ant/readable-stream': 0.4.1
+      is-stream: 4.0.1
+
   get-tsconfig@4.13.7:
     dependencies:
       resolve-pkg-maps: 1.0.0
@@ -21511,6 +23510,13 @@ snapshots:
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
+
+  gifwrap@0.10.1:
+    dependencies:
+      image-q: 4.0.0
+      omggif: 1.0.10
+
+  giget@3.3.0: {}
 
   github-from-package@0.0.0: {}
 
@@ -21620,6 +23626,8 @@ snapshots:
   hachure-fill@0.5.2: {}
 
   has-flag@4.0.0: {}
+
+  has-flag@5.0.1: {}
 
   has-property-descriptors@1.0.2:
     dependencies:
@@ -21868,6 +23876,8 @@ snapshots:
 
   human-signals@5.0.0: {}
 
+  human-signals@8.0.1: {}
+
   humanize-ms@1.2.1:
     dependencies:
       ms: 2.1.3
@@ -21884,7 +23894,17 @@ snapshots:
 
   ignore@7.0.5: {}
 
+  image-q@4.0.0:
+    dependencies:
+      '@types/node': 16.9.1
+
   immediate@3.0.6: {}
+
+  import-in-the-middle@3.3.2:
+    dependencies:
+      cjs-module-lexer: 2.2.0
+      es-module-lexer: 2.3.1
+      module-details-from-path: 1.0.4
 
   import-lazy@4.0.0: {}
 
@@ -21892,9 +23912,51 @@ snapshots:
 
   indent-string@4.0.0: {}
 
+  indent-string@5.0.0: {}
+
   inherits@2.0.4: {}
 
   ini@1.3.8: {}
+
+  ink-spinner@5.0.0(ink@7.1.0(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7))(react@19.2.7):
+    dependencies:
+      cli-spinners: 2.9.2
+      ink: 7.1.0(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)
+      react: 19.2.7
+
+  ink@7.1.0(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7):
+    dependencies:
+      '@alcalzone/ansi-tokenize': 0.3.0
+      ansi-escapes: 7.3.0
+      ansi-styles: 6.2.3
+      auto-bind: 5.0.1
+      chalk: 5.6.2
+      cli-boxes: 4.0.1
+      cli-cursor: 4.0.0
+      cli-truncate: 6.1.1
+      code-excerpt: 4.0.0
+      es-toolkit: 1.49.0
+      indent-string: 5.0.0
+      is-in-ci: 2.0.0
+      patch-console: 2.0.0
+      react: 19.2.7
+      react-reconciler: 0.33.0(react@19.2.7)
+      scheduler: 0.27.0
+      signal-exit: 3.0.7
+      slice-ansi: 9.0.0
+      stack-utils: 2.0.6
+      string-width: 8.2.2
+      terminal-size: 4.0.1
+      type-fest: 5.8.0
+      widest-line: 6.0.0
+      wrap-ansi: 10.0.0
+      ws: 8.21.0(bufferutil@4.1.0)
+      yoga-layout: 3.2.1
+    optionalDependencies:
+      '@types/react': 19.2.17
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   inline-style-parser@0.2.7: {}
 
@@ -21951,6 +24013,10 @@ snapshots:
 
   is-fullwidth-code-point@3.0.0: {}
 
+  is-fullwidth-code-point@5.1.0:
+    dependencies:
+      get-east-asian-width: 1.6.0
+
   is-generator-function@1.1.2:
     dependencies:
       call-bound: 1.0.4
@@ -21965,9 +24031,13 @@ snapshots:
 
   is-hexadecimal@2.0.1: {}
 
+  is-in-ci@2.0.0: {}
+
   is-inside-container@1.0.0:
     dependencies:
       is-docker: 3.0.0
+
+  is-interactive@2.0.0: {}
 
   is-nan@1.3.2:
     dependencies:
@@ -21993,9 +24063,13 @@ snapshots:
 
   is-stream@3.0.0: {}
 
+  is-stream@4.0.1: {}
+
   is-typed-array@1.1.15:
     dependencies:
       which-typed-array: 1.1.22
+
+  is-unicode-supported@2.1.0: {}
 
   is-wsl@2.2.0:
     dependencies:
@@ -22028,6 +24102,38 @@ snapshots:
       async: 3.2.6
       filelist: 1.0.6
       picocolors: 1.1.1
+
+  jimp@1.6.1:
+    dependencies:
+      '@jimp/core': 1.6.1
+      '@jimp/diff': 1.6.1
+      '@jimp/js-bmp': 1.6.1
+      '@jimp/js-gif': 1.6.1
+      '@jimp/js-jpeg': 1.6.1
+      '@jimp/js-png': 1.6.1
+      '@jimp/js-tiff': 1.6.1
+      '@jimp/plugin-blit': 1.6.1
+      '@jimp/plugin-blur': 1.6.1
+      '@jimp/plugin-circle': 1.6.1
+      '@jimp/plugin-color': 1.6.1
+      '@jimp/plugin-contain': 1.6.1
+      '@jimp/plugin-cover': 1.6.1
+      '@jimp/plugin-crop': 1.6.1
+      '@jimp/plugin-displace': 1.6.1
+      '@jimp/plugin-dither': 1.6.1
+      '@jimp/plugin-fisheye': 1.6.1
+      '@jimp/plugin-flip': 1.6.1
+      '@jimp/plugin-hash': 1.6.1
+      '@jimp/plugin-mask': 1.6.1
+      '@jimp/plugin-print': 1.6.1
+      '@jimp/plugin-quantize': 1.6.1
+      '@jimp/plugin-resize': 1.6.1
+      '@jimp/plugin-rotate': 1.6.1
+      '@jimp/plugin-threshold': 1.6.1
+      '@jimp/types': 1.6.1
+      '@jimp/utils': 1.6.1
+    transitivePeerDependencies:
+      - supports-color
 
   jiti@1.21.7: {}
 
@@ -22062,6 +24168,8 @@ snapshots:
       react: 19.2.7
 
   joycon@3.1.1: {}
+
+  jpeg-js@0.4.4: {}
 
   js-tiktoken@1.0.21:
     dependencies:
@@ -22134,7 +24242,7 @@ snapshots:
 
   kolorist@1.8.0: {}
 
-  langsmith@0.3.87(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0(bufferutil@4.1.0))(zod@4.3.6)):
+  langsmith@0.3.87(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.21.0(bufferutil@4.1.0))(zod@4.3.6)):
     dependencies:
       '@types/uuid': 10.0.0
       chalk: 4.1.2
@@ -22144,6 +24252,8 @@ snapshots:
       uuid: 10.0.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
+      '@opentelemetry/exporter-trace-otlp-proto': 0.218.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.10.0(@opentelemetry/api@1.9.0)
       openai: 4.104.0(ws@8.20.0(bufferutil@4.1.0))(zod@4.3.6)
 
   layout-base@1.0.2: {}
@@ -22167,6 +24277,10 @@ snapshots:
     optional: true
 
   lilconfig@3.1.3: {}
+
+  line-column-path@3.0.0:
+    dependencies:
+      type-fest: 2.19.0
 
   lines-and-columns@1.2.4: {}
 
@@ -22198,6 +24312,11 @@ snapshots:
   lodash@4.17.23: {}
 
   lodash@4.18.1: {}
+
+  log-symbols@7.0.1:
+    dependencies:
+      is-unicode-supported: 2.1.0
+      yoctocolors: 2.1.2
 
   loglevel@1.9.2: {}
 
@@ -22259,6 +24378,17 @@ snapshots:
       uc.micro: 2.1.0
 
   markdown-table@3.0.4: {}
+
+  marked-terminal@7.3.0(marked@15.0.12):
+    dependencies:
+      ansi-escapes: 7.3.0
+      ansi-regex: 6.2.2
+      chalk: 5.6.2
+      cli-highlight: 2.1.11
+      cli-table3: 0.6.5
+      marked: 15.0.12
+      node-emoji: 2.2.0
+      supports-hyperlinks: 3.2.0
 
   marked@15.0.12: {}
 
@@ -22784,11 +24914,15 @@ snapshots:
     dependencies:
       mime-db: 1.54.0
 
+  mime@3.0.0: {}
+
   mime@4.1.0: {}
 
   mimic-fn@2.1.0: {}
 
   mimic-fn@4.0.0: {}
+
+  mimic-function@5.0.1: {}
 
   mimic-response@3.1.0: {}
 
@@ -22829,6 +24963,8 @@ snapshots:
       pathe: 2.0.3
       pkg-types: 1.3.1
       ufo: 1.6.4
+
+  module-details-from-path@1.0.4: {}
 
   monaco-editor@0.52.2: {}
 
@@ -22873,11 +25009,11 @@ snapshots:
 
   nf3@0.3.22: {}
 
-  nitro@3.0.260610-beta(aws4fetch@1.0.20)(better-sqlite3@12.8.0)(chokidar@5.0.0)(dotenv@16.6.1)(drizzle-orm@0.44.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0))(jiti@2.7.0)(lru-cache@11.2.7):
+  nitro@3.0.260610-beta(aws4fetch@1.0.20)(better-sqlite3@12.8.0)(chokidar@5.0.0)(dotenv@17.4.2)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9))(giget@3.3.0)(jiti@2.7.0)(lru-cache@11.2.7):
     dependencies:
       consola: 3.4.2
       crossws: 0.4.10(srvx@0.11.22)
-      db0: 0.3.4(better-sqlite3@12.8.0)(drizzle-orm@0.44.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0))
+      db0: 0.3.4(better-sqlite3@12.8.0)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9))
       env-runner: 0.1.16
       h3: 2.0.1-rc.22(crossws@0.4.10(srvx@0.11.22))
       hookable: 6.1.1
@@ -22888,9 +25024,10 @@ snapshots:
       rolldown: 1.2.0
       srvx: 0.11.22
       unenv: 2.0.0-rc.24
-      unstorage: 2.0.0-alpha.7(aws4fetch@1.0.20)(chokidar@5.0.0)(db0@0.3.4(better-sqlite3@12.8.0)(drizzle-orm@0.44.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)))(lru-cache@11.2.7)(ofetch@2.0.0-alpha.3)
+      unstorage: 2.0.0-alpha.7(aws4fetch@1.0.20)(chokidar@5.0.0)(db0@0.3.4(better-sqlite3@12.8.0)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)))(lru-cache@11.2.7)(ofetch@2.0.0-alpha.3)
     optionalDependencies:
-      dotenv: 16.6.1
+      dotenv: 17.4.2
+      giget: 3.3.0
       jiti: 2.7.0
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -22933,6 +25070,13 @@ snapshots:
       semver: 7.8.5
 
   node-domexception@1.0.0: {}
+
+  node-emoji@2.2.0:
+    dependencies:
+      '@sindresorhus/is': 4.6.0
+      char-regex: 1.0.2
+      emojilib: 2.4.0
+      skin-tone: 2.0.0
 
   node-fetch-native@1.6.7: {}
 
@@ -23006,6 +25150,11 @@ snapshots:
     dependencies:
       path-key: 4.0.0
 
+  npm-run-path@6.0.0:
+    dependencies:
+      path-key: 4.0.0
+      unicorn-magic: 0.3.0
+
   npm@11.18.0: {}
 
   nth-check@2.1.1:
@@ -23055,6 +25204,8 @@ snapshots:
       zod: 4.3.6
     optional: true
 
+  omggif@1.0.10: {}
+
   on-exit-leak-free@2.1.2: {}
 
   on-finished@2.4.1:
@@ -23073,6 +25224,10 @@ snapshots:
     dependencies:
       mimic-fn: 4.0.0
 
+  onetime@7.0.0:
+    dependencies:
+      mimic-function: 5.0.1
+
   oniguruma-parser@0.12.2: {}
 
   oniguruma-to-es@4.3.6:
@@ -23080,6 +25235,13 @@ snapshots:
       oniguruma-parser: 0.12.2
       regex: 6.1.0
       regex-recursion: 6.0.2
+
+  open-editor@5.1.0:
+    dependencies:
+      env-editor: 1.3.0
+      execa: 9.6.1
+      line-column-path: 3.0.0
+      open: 10.2.0
 
   open@10.2.0:
     dependencies:
@@ -23193,6 +25355,17 @@ snapshots:
   opencode-windows-x64@1.17.20:
     optional: true
 
+  ora@9.4.1:
+    dependencies:
+      chalk: 5.6.2
+      cli-cursor: 5.0.0
+      cli-spinners: 3.4.0
+      is-interactive: 2.0.0
+      is-unicode-supported: 2.1.0
+      log-symbols: 7.0.1
+      stdin-discarder: 0.3.2
+      string-width: 8.2.2
+
   os-browserify@0.3.0: {}
 
   os-paths@4.4.0: {}
@@ -23270,6 +25443,15 @@ snapshots:
       pbkdf2: 3.1.6
       safe-buffer: 5.2.1
 
+  parse-bmfont-ascii@1.0.6: {}
+
+  parse-bmfont-binary@1.0.6: {}
+
+  parse-bmfont-xml@1.1.6:
+    dependencies:
+      xml-parse-from-string: 1.0.1
+      xml2js: 0.5.0
+
   parse-entities@4.0.2:
     dependencies:
       '@types/unist': 2.0.11
@@ -23289,6 +25471,8 @@ snapshots:
       unist-util-visit-children: 3.0.0
       vfile: 6.0.3
 
+  parse-ms@4.0.0: {}
+
   parse5-htmlparser2-tree-adapter@6.0.1:
     dependencies:
       parse5: 6.0.1
@@ -23304,6 +25488,8 @@ snapshots:
   parseurl@1.3.3: {}
 
   partial-json@0.1.7: {}
+
+  patch-console@2.0.0: {}
 
   patchright-core@1.59.4:
     optional: true
@@ -23435,6 +25621,10 @@ snapshots:
 
   pirates@4.0.7: {}
 
+  pixelmatch@5.3.0:
+    dependencies:
+      pngjs: 6.0.0
+
   pkce-challenge@5.0.1: {}
 
   pkg-dir@5.0.0:
@@ -23454,6 +25644,10 @@ snapshots:
       playwright-core: 1.59.1
     optionalDependencies:
       fsevents: 2.3.2
+
+  pngjs@6.0.0: {}
+
+  pngjs@7.0.0: {}
 
   points-on-curve@0.2.0: {}
 
@@ -23524,6 +25718,8 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  postgres@3.4.9: {}
+
   posthog-js@1.406.2:
     dependencies:
       '@posthog/browser-common': 0.2.0
@@ -23554,6 +25750,10 @@ snapshots:
       simple-get: 4.0.1
       tar-fs: 2.1.4
       tunnel-agent: 0.6.0
+
+  pretty-ms@9.3.0:
+    dependencies:
+      parse-ms: 4.0.0
 
   prismjs@1.30.0: {}
 
@@ -23759,6 +25959,11 @@ snapshots:
       vfile: 6.0.3
     transitivePeerDependencies:
       - supports-color
+
+  react-reconciler@0.33.0(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+      scheduler: 0.27.0
 
   react-refresh@0.17.0: {}
 
@@ -24076,6 +26281,13 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
+  require-in-the-middle@8.0.1:
+    dependencies:
+      debug: 4.4.3(supports-color@8.1.1)
+      module-details-from-path: 1.0.4
+    transitivePeerDependencies:
+      - supports-color
+
   resolve-from@5.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
@@ -24090,6 +26302,16 @@ snapshots:
       is-core-module: 2.16.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
+
+  restore-cursor@4.0.0:
+    dependencies:
+      onetime: 5.1.2
+      signal-exit: 3.0.7
+
+  restore-cursor@5.1.0:
+    dependencies:
+      onetime: 7.0.0
+      signal-exit: 4.1.0
 
   retext-latin@4.0.0:
     dependencies:
@@ -24127,7 +26349,7 @@ snapshots:
       hash-base: 3.1.2
       inherits: 2.0.4
 
-  rivetkit@2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0)):
+  rivetkit@2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0)):
     dependencies:
       '@hono/zod-openapi': 1.4.0(hono@4.12.9)(zod@4.3.6)
       '@rivet-dev/agent-os-core': 0.1.1(pyodide@0.28.3(bufferutil@4.1.0))
@@ -24141,7 +26363,7 @@ snapshots:
       '@rivetkit/virtual-websocket': 2.3.7
       '@rivetkit/workflow-engine': 2.3.7
       cbor-x: 1.6.4
-      drizzle-orm: 0.44.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)
+      drizzle-orm: 0.44.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)
       hono: 4.12.9
       invariant: 2.2.4
       p-retry: 6.2.1
@@ -24504,6 +26726,8 @@ snapshots:
 
   simple-wcswidth@1.1.2: {}
 
+  simple-xml-to-json@1.2.7: {}
+
   sisteransi@1.0.5: {}
 
   sitemap@9.0.1:
@@ -24512,6 +26736,15 @@ snapshots:
       '@types/sax': 1.2.7
       arg: 5.0.2
       sax: 1.6.0
+
+  skin-tone@2.0.0:
+    dependencies:
+      unicode-emoji-modifier-base: 1.0.0
+
+  slice-ansi@9.0.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 5.1.0
 
   smart-buffer@4.2.0: {}
 
@@ -24563,6 +26796,10 @@ snapshots:
       cpu-features: 0.0.10
       nan: 2.26.2
 
+  stack-utils@2.0.6:
+    dependencies:
+      escape-string-regexp: 2.0.0
+
   stackback@0.0.2: {}
 
   standardwebhooks@1.0.0:
@@ -24573,6 +26810,8 @@ snapshots:
   statuses@2.0.2: {}
 
   std-env@3.10.0: {}
+
+  stdin-discarder@0.3.2: {}
 
   stream-browserify@3.0.0:
     dependencies:
@@ -24617,6 +26856,11 @@ snapshots:
       get-east-asian-width: 1.6.0
       strip-ansi: 7.2.0
 
+  string-width@8.2.2:
+    dependencies:
+      get-east-asian-width: 1.6.0
+      strip-ansi: 7.2.0
+
   string_decoder@1.1.1:
     dependencies:
       safe-buffer: 5.1.2
@@ -24641,6 +26885,8 @@ snapshots:
   strip-final-newline@2.0.0: {}
 
   strip-final-newline@3.0.0: {}
+
+  strip-final-newline@4.0.0: {}
 
   strip-json-comments@2.0.1: {}
 
@@ -24676,6 +26922,8 @@ snapshots:
       tinyglobby: 0.2.15
       ts-interface-checker: 0.1.13
 
+  supports-color@10.2.2: {}
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -24683,6 +26931,16 @@ snapshots:
   supports-color@8.1.1:
     dependencies:
       has-flag: 4.0.0
+
+  supports-hyperlinks@3.2.0:
+    dependencies:
+      has-flag: 4.0.0
+      supports-color: 7.2.0
+
+  supports-hyperlinks@4.5.0:
+    dependencies:
+      has-flag: 5.0.1
+      supports-color: 10.2.2
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
@@ -24702,6 +26960,8 @@ snapshots:
       tslib: 2.8.1
 
   tabbable@6.5.0: {}
+
+  tagged-tag@1.0.0: {}
 
   tailwind-merge@2.6.1: {}
 
@@ -24793,6 +27053,13 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
+  terminal-link@5.0.0:
+    dependencies:
+      ansi-escapes: 7.3.0
+      supports-hyperlinks: 4.5.0
+
+  terminal-size@4.0.1: {}
+
   text-decoder@1.2.7:
     dependencies:
       b4a: 1.8.0
@@ -24823,6 +27090,8 @@ snapshots:
   tiny-invariant@1.3.3: {}
 
   tinybench@2.9.0: {}
+
+  tinycolor2@1.6.0: {}
 
   tinyexec@0.3.2: {}
 
@@ -24980,7 +27249,13 @@ snapshots:
 
   type-fest@0.21.3: {}
 
+  type-fest@2.19.0: {}
+
   type-fest@4.41.0: {}
+
+  type-fest@5.8.0:
+    dependencies:
+      tagged-tag: 1.0.0
 
   type-is@2.0.1:
     dependencies:
@@ -25055,6 +27330,10 @@ snapshots:
   unenv@2.0.0-rc.24:
     dependencies:
       pathe: 2.0.3
+
+  unicode-emoji-modifier-base@1.0.0: {}
+
+  unicorn-magic@0.3.0: {}
 
   unified@11.0.5:
     dependencies:
@@ -25143,7 +27422,7 @@ snapshots:
 
   unpipe@1.0.0: {}
 
-  unstorage@1.17.5(aws4fetch@1.0.20)(db0@0.3.4(better-sqlite3@12.8.0)(drizzle-orm@0.44.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0))):
+  unstorage@1.17.5(aws4fetch@1.0.20)(db0@0.3.4(better-sqlite3@12.8.0)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9))):
     dependencies:
       anymatch: 3.1.3
       chokidar: 5.0.0
@@ -25155,13 +27434,13 @@ snapshots:
       ufo: 1.6.4
     optionalDependencies:
       aws4fetch: 1.0.20
-      db0: 0.3.4(better-sqlite3@12.8.0)(drizzle-orm@0.44.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0))
+      db0: 0.3.4(better-sqlite3@12.8.0)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9))
 
-  unstorage@2.0.0-alpha.7(aws4fetch@1.0.20)(chokidar@5.0.0)(db0@0.3.4(better-sqlite3@12.8.0)(drizzle-orm@0.44.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)))(lru-cache@11.2.7)(ofetch@2.0.0-alpha.3):
+  unstorage@2.0.0-alpha.7(aws4fetch@1.0.20)(chokidar@5.0.0)(db0@0.3.4(better-sqlite3@12.8.0)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9)))(lru-cache@11.2.7)(ofetch@2.0.0-alpha.3):
     optionalDependencies:
       aws4fetch: 1.0.20
       chokidar: 5.0.0
-      db0: 0.3.4(better-sqlite3@12.8.0)(drizzle-orm@0.44.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0))
+      db0: 0.3.4(better-sqlite3@12.8.0)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(postgres@3.4.9))
       lru-cache: 11.2.7
       ofetch: 2.0.0-alpha.3
 
@@ -25224,6 +27503,10 @@ snapshots:
       lodash.debounce: 4.0.8
       react: 19.2.7
 
+  utif2@4.1.0:
+    dependencies:
+      pako: 1.0.11
+
   util-deprecate@1.0.2: {}
 
   util@0.12.5:
@@ -25241,6 +27524,8 @@ snapshots:
   uuid@11.1.1: {}
 
   uuid@12.0.1: {}
+
+  uuid@14.0.1: {}
 
   uuid@9.0.1: {}
 
@@ -25528,7 +27813,17 @@ snapshots:
     dependencies:
       string-width: 7.2.0
 
+  widest-line@6.0.0:
+    dependencies:
+      string-width: 8.2.2
+
   wordwrap@1.0.0: {}
+
+  wrap-ansi@10.0.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 8.2.2
+      strip-ansi: 7.2.0
 
   wrap-ansi@7.0.0:
     dependencies:
@@ -25569,6 +27864,15 @@ snapshots:
   xdg-portable@7.3.0:
     dependencies:
       os-paths: 4.4.0
+
+  xml-parse-from-string@1.0.1: {}
+
+  xml2js@0.5.0:
+    dependencies:
+      sax: 1.6.0
+      xmlbuilder: 11.0.1
+
+  xmlbuilder@11.0.1: {}
 
   xtend@4.0.2: {}
 
@@ -25622,6 +27926,8 @@ snapshots:
       yoctocolors: 2.1.2
 
   yoctocolors@2.1.2: {}
+
+  yoga-layout@3.2.1: {}
 
   z-schema@5.0.5:
     dependencies:

--- a/software/command-code/agentos-package.json
+++ b/software/command-code/agentos-package.json
@@ -1,0 +1,10 @@
+{
+	"commands": ["cmd", "cmdc", "command-code", "commandcode"],
+	"registry": {
+		"title": "Command Code",
+		"description": "Command Code v1 coding-agent CLI.",
+		"category": "agents",
+		"docsHref": "/docs/agents/command-code",
+		"priority": 75
+	}
+}

--- a/software/command-code/package.json
+++ b/software/command-code/package.json
@@ -1,0 +1,47 @@
+{
+	"name": "@agentos-software/command-code",
+	"version": "0.0.1",
+	"type": "module",
+	"license": "UNLICENSED",
+	"description": "Command Code v1 CLI packaged for agentOS VMs",
+	"engines": {
+		"node": ">=22.0.0"
+	},
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"bin": {
+		"cmd": "./dist/command-code/index.mjs",
+		"cmdc": "./dist/command-code/index.mjs",
+		"command-code": "./dist/command-code/index.mjs",
+		"commandcode": "./dist/command-code/index.mjs"
+	},
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js",
+			"default": "./dist/index.js"
+		}
+	},
+	"files": [
+		"dist",
+		"!dist/package",
+		"!dist/package.tar",
+		"agentos-package.json"
+	],
+	"scripts": {
+		"build": "rm -rf dist && tsc && node scripts/stage-upstream-cli.mjs && agentos-toolchain pack . --out dist/package --prune-native --omit-optional",
+		"check-types": "tsc --noEmit",
+		"test": "pnpm build && node --test --test-force-exit tests/*.test.mjs"
+	},
+	"dependencies": {
+		"@crosscopy/clipboard": "0.2.8"
+	},
+	"devDependencies": {
+		"@agentos-software/manifest": "workspace:*",
+		"@rivet-dev/agentos-toolchain": "workspace:*",
+		"@types/node": "^22.10.2",
+		"command-code": "1.1.0",
+		"esbuild": "0.27.4",
+		"typescript": "^5.7.2"
+	}
+}

--- a/software/command-code/scripts/stage-upstream-cli.mjs
+++ b/software/command-code/scripts/stage-upstream-cli.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+
+import { build } from "esbuild";
+import {
+	chmodSync,
+	mkdirSync,
+	readFileSync,
+	writeFileSync,
+} from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, resolve } from "node:path";
+
+const require = createRequire(import.meta.url);
+const cliPath = require.resolve("command-code");
+const upstreamDir = dirname(cliPath);
+const upstreamPackage = JSON.parse(
+	readFileSync(resolve(upstreamDir, "..", "package.json"), "utf8"),
+);
+const outputDir = resolve(import.meta.dirname, "..", "dist", "command-code");
+const outputCli = resolve(outputDir, "cli.mjs");
+
+const defaultImport = 'import De from"@opentelemetry/semantic-conventions";';
+const namespaceImport = 'import*as De from"@opentelemetry/semantic-conventions";';
+const source = readFileSync(cliPath, "utf8");
+if (source.split(defaultImport).length !== 2) {
+	throw new Error(
+		"Command Code's semantic-conventions import changed; review the bundling compatibility patch",
+	);
+}
+
+mkdirSync(outputDir, { recursive: true });
+await build({
+	entryPoints: [cliPath],
+	outfile: outputCli,
+	bundle: true,
+	platform: "node",
+	target: "node22",
+	format: "esm",
+	banner: {
+		js: 'import { createRequire as __createRequire } from "node:module"; const require = __createRequire(import.meta.url);',
+	},
+	external: ["@crosscopy/clipboard"],
+	plugins: [
+		{
+			name: "command-code-runtime-compat",
+			setup(buildApi) {
+				buildApi.onLoad({ filter: /.*/, namespace: "file" }, (args) => {
+					if (args.path !== cliPath) return undefined;
+					return {
+						contents: source.replace(defaultImport, namespaceImport),
+						loader: "js",
+						resolveDir: upstreamDir,
+					};
+				});
+				buildApi.onResolve({ filter: /^react-devtools-core$/ }, () => ({
+					path: "react-devtools-core",
+					namespace: "command-code-empty",
+				}));
+				buildApi.onLoad(
+					{ filter: /.*/, namespace: "command-code-empty" },
+					() => ({
+						contents: "export default { connectToDevTools() {} };",
+						loader: "js",
+					}),
+				);
+			},
+		},
+	],
+});
+
+writeFileSync(
+	resolve(outputDir, "index.mjs"),
+	readFileSync(resolve(upstreamDir, "index.mjs")),
+);
+writeFileSync(
+	resolve(outputDir, "package.json"),
+	`${JSON.stringify(
+		{
+			name: upstreamPackage.name,
+			version: upstreamPackage.version,
+			type: "module",
+		},
+		null,
+		2,
+	)}\n`,
+);
+writeFileSync(
+	resolve(outputDir, "agentos-build.json"),
+	`${JSON.stringify(
+		{
+			sourcePackage: `${upstreamPackage.name}@${upstreamPackage.version}`,
+			patches: [
+				"bundle runtime dependencies for a bounded registry artifact",
+				"normalize the semantic-conventions namespace import for bundling",
+				"stub Ink's undeclared react-devtools-core development-only export",
+			],
+		},
+		null,
+		2,
+	)}\n`,
+);
+chmodSync(resolve(outputDir, "index.mjs"), 0o755);
+
+process.stdout.write(
+	`Staged Command Code ${upstreamPackage.version} as a bundled Node.js CLI\n`,
+);

--- a/software/command-code/src/index.ts
+++ b/software/command-code/src/index.ts
@@ -1,0 +1,5 @@
+import type { SoftwarePackageRef } from "@agentos-software/manifest";
+
+const packagePath = new URL("./package.aospkg", import.meta.url).pathname;
+
+export default { packagePath } satisfies SoftwarePackageRef;

--- a/software/command-code/tests/package.test.mjs
+++ b/software/command-code/tests/package.test.mjs
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { readFileSync, statSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+import commandCode from "../dist/index.js";
+
+const packageDir = resolve(import.meta.dirname, "..");
+
+test("package exposes the genuine Command Code v1 CLI aliases", () => {
+	const pkg = JSON.parse(readFileSync(resolve(packageDir, "package.json"), "utf8"));
+	const manifest = JSON.parse(
+		readFileSync(resolve(packageDir, "agentos-package.json"), "utf8"),
+	);
+	const stagedBuild = JSON.parse(
+		readFileSync(
+			resolve(packageDir, "dist/command-code/agentos-build.json"),
+			"utf8",
+		),
+	);
+
+	assert.equal(pkg.version, "0.0.1");
+	assert.equal(pkg.license, "UNLICENSED");
+	assert.equal(pkg.devDependencies["command-code"], "1.1.0");
+	assert.deepEqual(
+		Object.keys(pkg.bin).sort(),
+		["cmd", "cmdc", "command-code", "commandcode"],
+	);
+	assert.deepEqual(manifest.commands, [
+		"cmd",
+		"cmdc",
+		"command-code",
+		"commandcode",
+	]);
+	assert.equal(manifest.registry.category, "agents");
+	assert.equal(stagedBuild.sourcePackage, "command-code@1.1.0");
+	assert.equal(typeof commandCode.packagePath, "string");
+	assert.equal(statSync(commandCode.packagePath).isFile(), true);
+
+	const packResult = JSON.parse(
+		execFileSync("npm", ["pack", "--dry-run", "--json"], {
+			cwd: packageDir,
+			encoding: "utf8",
+		}),
+	);
+	assert.equal(
+		packResult[0].files.some((file) => file.path === "dist/package.aospkg"),
+		true,
+	);
+});
+
+test("every packaged alias starts the upstream CLI", () => {
+	for (const alias of ["cmd", "cmdc", "command-code", "commandcode"]) {
+		const output = execFileSync(resolve(packageDir, `dist/package/bin/${alias}`), [
+			"--version",
+		], {
+			encoding: "utf8",
+		});
+		assert.equal(output.trim(), "1.1.0");
+	}
+});

--- a/software/command-code/tsconfig.json
+++ b/software/command-code/tsconfig.json
@@ -1,0 +1,10 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"declaration": true,
+		"outDir": "./dist",
+		"rootDir": "./src"
+	},
+	"include": ["src/**/*"],
+	"exclude": ["node_modules", "dist"]
+}

--- a/website/public/docs/docs/agents/command-code.md
+++ b/website/public/docs/docs/agents/command-code.md
@@ -21,38 +21,45 @@ The agentOS end-to-end test runs the packaged command in a real VM and verifies:
 - version and help output;
 - unauthenticated status JSON and the documented headless authentication exit code;
 - `.agents/skills/` discovery with `cmd skills list --debug`;
+- local TypeScript mod installation and discovery with `cmd mods add` / `list`;
 - project-scoped HTTP MCP add/get configuration and the resulting `.mcp.json`;
 - all four projected command aliases.
 
-The opt-in live test also verifies API-key authentication and reaches Command Code's hosted model endpoint. The available test key reached the billing boundary but had insufficient credits, so a complete generated model response has not been validated. Interactive help was also exercised through an agentOS terminal, but a complete interactive login and model turn has not been validated.
+The opt-in network test installs the pinned `cmd-mod-hi@0.1.1` npm mod in a standard VM. npm-backed mods require the default `common` software bundle's `sh`; a minimal VM created with `defaultSoftware: false` must add `@agentos-software/coreutils`. The opt-in live test also verifies API-key authentication and reaches Command Code's hosted model endpoint. The available test key reached the billing boundary but had insufficient credits, so a complete generated model response has not been validated. Interactive help was also exercised through an agentOS terminal, but a complete interactive login and model turn has not been validated.
 
 ## Runtime support matrix
 
-Legend: **Supported** is documented by Command Code on native Linux; **Tested** was exercised end to end in an agentOS VM; **Expected** has the required agentOS primitive but has not been exercised through an authenticated Command Code turn; **Partial** names an important limitation; **Unsupported** lacks the execution model the CLI requires.
+Legend: 🟢 **Supported** means the platform provides the required behavior and we are confident it works; 🟡 **Partial** identifies a concrete limitation or an important path that still needs validation; 🔴 **Unsupported** means the platform or deployment model cannot provide the behavior. Rows say when agentOS support was exercised end to end.
 
 | Command Code surface | Native Linux | agentOS VM | Direct Cloudflare Worker isolate |
 | --- | --- | --- | --- |
-| CLI startup, `--version`, `--help`, aliases | Supported | **Tested** | **Unsupported**: no standalone Node CLI/process entrypoint |
-| API-key authentication | Supported | **Tested** with an opt-in live test | **Unsupported** as a full CLI |
-| Browser login / MCP OAuth browser flow | Supported | **Partial**: automatic host-browser opening is not validated; API keys are preferred | **Unsupported** as a local CLI |
-| Interactive TUI and TTY input | Supported | **Partial**: terminal startup/help tested; full interactive turn untested | **Unsupported**: `node:tty`, `readline`, and REPL are non-functional stubs |
-| Headless `-p`, JSON/NDJSON, piped stdin, exit codes | Supported | **Partial**: unauthenticated and authenticated billing boundaries tested; funded generation and streaming untested | **Unsupported** as a full CLI |
-| File read, grep, glob | Supported | **Expected**, not tested through a model turn | **Unsupported** for this CLI: Worker VFS has no glob APIs and no normal project tree |
-| File edit/write | Supported (permission gated) | **Expected**, subject to VM filesystem policy | **Unsupported** for a durable project: only request-local `/tmp` is writable |
-| Shell commands and hooks | Supported (permission gated) | **Expected**, subject to VM process policy; hook execution untested | **Unsupported**: `node:child_process` is a non-functional stub |
-| Git and managed worktrees | Supported | **Expected** when Git is installed; not tested with Command Code | **Unsupported**: no child processes or durable project filesystem |
-| Persisted sessions, resume, fork, rewind | Supported | **Expected** on the VM filesystem; not tested | **Unsupported**: request-local VFS is not persistent |
-| Skills and `.agents/skills/` | Supported | **Tested** for project discovery/listing | **Unsupported** as a CLI; bundled files alone do not provide the required process model |
-| MCP configuration | Supported | **Tested** for project-scoped HTTP add/get | **Unsupported** as a full CLI |
-| MCP HTTP/SSE tool use | Supported | **Expected**, subject to VM network policy; live server untested | **Unsupported** as a full CLI, even though Workers can make HTTP requests |
-| MCP stdio servers | Supported | **Expected**, subject to installed commands and process policy; untested | **Unsupported**: no child processes |
-| Mods and local package installation | Supported | **Partial**: not validated; native dependencies may require compatible agentOS software | **Unsupported**: no package manager or child processes |
-| Clipboard copy and image paste | Supported when a host clipboard is available | **Unsupported**: the VM has no host clipboard and native N-API clipboard binding | **Unsupported**: no host terminal clipboard |
-| Auto-update | Supported | **Unsupported** for the projected registry package; pass `--no-auto-update` | **Unsupported** |
+| CLI startup, `--version`, `--help`, aliases | 🟢 Supported | 🟢 Supported — tested end to end | 🔴 Unsupported — no standalone Node CLI/process entrypoint |
+| API-key authentication | 🟢 Supported | 🟢 Supported — tested against the hosted service | 🔴 Unsupported as a full CLI |
+| Browser login / MCP OAuth browser flow | 🟢 Supported | 🟡 Partial — automatic host-browser opening is not validated; API keys are preferred | 🔴 Unsupported as a local CLI |
+| Interactive TUI and TTY input | 🟢 Supported | 🟡 Partial — terminal startup/help works; a funded interactive model turn is untested | 🔴 Unsupported — `node:tty`, `readline`, and REPL are non-functional stubs |
+| Headless `-p`, JSON/NDJSON, piped stdin, exit codes | 🟢 Supported | 🟡 Partial — authentication and the hosted billing boundary work; completed generation and streaming remain untested | 🔴 Unsupported as a full CLI |
+| Filesystem read/write and JS glob | 🟢 Supported | 🟢 Supported — backed by the VM VFS and Node `fs`/`fs.promises.glob`; VM policy still applies | 🔴 Unsupported for this CLI — no normal durable project tree |
+| Text search / ripgrep | 🟢 Supported | 🟡 Partial — install `@agentos-software/ripgrep`; a model-driven search is untested | 🔴 Unsupported for this CLI — Worker VFS has no glob APIs or normal project tree |
+| Shell commands and hooks | 🟢 Supported (permission gated) | 🟢 Supported with the default `common` software bundle; VM process policy still applies | 🔴 Unsupported — `node:child_process` is a non-functional stub |
+| Git and managed worktrees | 🟢 Supported | 🟡 Partial — requires `@agentos-software/git`; Command Code's managed-worktree flow is untested | 🔴 Unsupported — no child processes or durable project filesystem |
+| Persisted sessions, resume, fork, rewind | 🟢 Supported | 🟢 Supported — session files live on the VM filesystem; durability follows the configured filesystem | 🔴 Unsupported — request-local VFS is not persistent |
+| Skills and `.agents/skills/` | 🟢 Supported | 🟢 Supported — project discovery/listing tested end to end | 🔴 Unsupported as a CLI |
+| MCP configuration | 🟢 Supported | 🟢 Supported — project-scoped HTTP add/get tested end to end | 🔴 Unsupported as a full CLI |
+| MCP HTTP/SSE tool use | 🟢 Supported | 🟡 Partial — the VM has HTTP/SSE networking, but a live MCP tool round trip is untested | 🔴 Unsupported as a full CLI, even though Workers can make HTTP requests |
+| MCP stdio servers | 🟢 Supported | 🟡 Partial — process support exists, but a Command Code stdio MCP round trip is untested | 🔴 Unsupported — no child processes |
+| Local TypeScript mods (`--mod`, local `mods add`) | 🟢 Supported | 🟢 Supported — install, compile, and discovery tested end to end | 🔴 Unsupported — no CLI process or persistent mod directory |
+| npm TypeScript mods | 🟢 Supported | 🟢 Supported — pinned registry install tested with the default `common` bundle | 🔴 Unsupported — no package manager or child processes |
+| Git-sourced mods | 🟢 Supported | 🟡 Partial — requires `@agentos-software/git`; this install path is untested | 🔴 Unsupported |
+| Mods with native Node add-ons | 🟡 Partial — only prebuilt add-ons can work because Command Code installs with `--ignore-scripts` | 🔴 Unsupported — VM Node execution does not load native Node add-ons | 🔴 Unsupported |
+| Clipboard copy and image paste | 🟢 Supported when a host clipboard is available | 🔴 Unsupported — the VM has no host clipboard or native N-API clipboard binding | 🔴 Unsupported — no host terminal clipboard |
+| Update checks (`cmd update --check-only`) | 🟢 Supported | 🟡 Partial — the upstream five-second npm version-query timeout can expire in a VM | 🔴 Unsupported as a CLI |
+| In-place auto/self-update | 🟢 Supported | 🔴 Unsupported by design — `/opt/agentos` packages are immutable; deploy a newer registry package instead | 🔴 Unsupported |
 
 This Cloudflare column evaluates running the npm CLI directly in a standard Worker isolate with `nodejs_compat`. It does not describe an official Command Code Worker implementation—none was found—and it does not cover [Cloudflare Sandbox](https://developers.cloudflare.com/agents/tools/sandbox/), which is a separate container product with a real filesystem and shell.
 
-Sources: [Command Code CLI reference](https://commandcode.ai/docs/reference/cli), [headless mode](https://commandcode.ai/docs/core-concepts/headless), [MCP](https://commandcode.ai/docs/mcp), [skills](https://commandcode.ai/docs/skills), [hooks](https://commandcode.ai/docs/hooks), [Cloudflare Node.js compatibility](https://developers.cloudflare.com/workers/runtime-apis/nodejs/), and [Cloudflare Worker filesystem](https://developers.cloudflare.com/workers/runtime-apis/nodejs/fs/).
+Self-update is intentionally different from ordinary command support. `cmd update` replaces the globally installed npm package, while agentOS projects a content-addressed, read-only package at `/opt/agentos`. Mutating that projection would break reproducibility, so run with `--no-auto-update` and upgrade the agentOS registry package from the host. Mods install into writable user/project storage instead, which is why local and pure TypeScript npm mods work; npm-backed installation needs `sh`, while Git sources need Git and native Node add-ons cannot load in the VM.
+
+Sources: [Command Code CLI reference](https://commandcode.ai/docs/reference/cli), [headless mode](https://commandcode.ai/docs/core-concepts/headless), [MCP](https://commandcode.ai/docs/mcp), [skills](https://commandcode.ai/docs/skills), [mods](https://commandcode.ai/docs/mods), [hooks](https://commandcode.ai/docs/hooks), [Cloudflare Node.js compatibility](https://developers.cloudflare.com/workers/runtime-apis/nodejs/), and [Cloudflare Worker filesystem](https://developers.cloudflare.com/workers/runtime-apis/nodejs/fs/).
 
 ## Permissions and updates
 

--- a/website/public/docs/docs/agents/command-code.md
+++ b/website/public/docs/docs/agents/command-code.md
@@ -1,0 +1,61 @@
+# Command Code CLI
+
+Run the genuine Command Code v1 CLI inside an agentOS VM.
+
+## Quick start
+
+The registry package projects `command-code@1.1.0` as `cmd`, `cmdc`, `command-code`, and `commandcode`. It uses the genuine upstream CLI, rebundled for the VM with compatibility patches recorded in the package's `agentos-build.json`. It is a command package, not an ACP agent. Invoke it with `execArgv` or attach a terminal for interactive use.
+
+The CLI is sourced from the npm release, whose package metadata is `UNLICENSED`; the public Command Code GitHub repository does not contain the CLI implementation. Review the upstream terms before publishing or redistributing the packed artifact.
+
+## Credentials
+
+Create a Command Code API key and pass it to the command as `COMMAND_CODE_API_KEY`, sourced from your server's environment. The credential stays inside the VM process environment and is read by the packaged Command Code CLI.
+
+See Command Code's [documentation](https://commandcode.ai/docs) for account and model details.
+
+## Verified command surface
+
+The agentOS end-to-end test runs the packaged command in a real VM and verifies:
+
+- version and help output;
+- unauthenticated status JSON and the documented headless authentication exit code;
+- `.agents/skills/` discovery with `cmd skills list --debug`;
+- project-scoped HTTP MCP add/get configuration and the resulting `.mcp.json`;
+- all four projected command aliases.
+
+The opt-in live test also verifies API-key authentication and reaches Command Code's hosted model endpoint. The available test key reached the billing boundary but had insufficient credits, so a complete generated model response has not been validated. Interactive help was also exercised through an agentOS terminal, but a complete interactive login and model turn has not been validated.
+
+## Runtime support matrix
+
+Legend: **Supported** is documented by Command Code on native Linux; **Tested** was exercised end to end in an agentOS VM; **Expected** has the required agentOS primitive but has not been exercised through an authenticated Command Code turn; **Partial** names an important limitation; **Unsupported** lacks the execution model the CLI requires.
+
+| Command Code surface | Native Linux | agentOS VM | Direct Cloudflare Worker isolate |
+| --- | --- | --- | --- |
+| CLI startup, `--version`, `--help`, aliases | Supported | **Tested** | **Unsupported**: no standalone Node CLI/process entrypoint |
+| API-key authentication | Supported | **Tested** with an opt-in live test | **Unsupported** as a full CLI |
+| Browser login / MCP OAuth browser flow | Supported | **Partial**: automatic host-browser opening is not validated; API keys are preferred | **Unsupported** as a local CLI |
+| Interactive TUI and TTY input | Supported | **Partial**: terminal startup/help tested; full interactive turn untested | **Unsupported**: `node:tty`, `readline`, and REPL are non-functional stubs |
+| Headless `-p`, JSON/NDJSON, piped stdin, exit codes | Supported | **Partial**: unauthenticated and authenticated billing boundaries tested; funded generation and streaming untested | **Unsupported** as a full CLI |
+| File read, grep, glob | Supported | **Expected**, not tested through a model turn | **Unsupported** for this CLI: Worker VFS has no glob APIs and no normal project tree |
+| File edit/write | Supported (permission gated) | **Expected**, subject to VM filesystem policy | **Unsupported** for a durable project: only request-local `/tmp` is writable |
+| Shell commands and hooks | Supported (permission gated) | **Expected**, subject to VM process policy; hook execution untested | **Unsupported**: `node:child_process` is a non-functional stub |
+| Git and managed worktrees | Supported | **Expected** when Git is installed; not tested with Command Code | **Unsupported**: no child processes or durable project filesystem |
+| Persisted sessions, resume, fork, rewind | Supported | **Expected** on the VM filesystem; not tested | **Unsupported**: request-local VFS is not persistent |
+| Skills and `.agents/skills/` | Supported | **Tested** for project discovery/listing | **Unsupported** as a CLI; bundled files alone do not provide the required process model |
+| MCP configuration | Supported | **Tested** for project-scoped HTTP add/get | **Unsupported** as a full CLI |
+| MCP HTTP/SSE tool use | Supported | **Expected**, subject to VM network policy; live server untested | **Unsupported** as a full CLI, even though Workers can make HTTP requests |
+| MCP stdio servers | Supported | **Expected**, subject to installed commands and process policy; untested | **Unsupported**: no child processes |
+| Mods and local package installation | Supported | **Partial**: not validated; native dependencies may require compatible agentOS software | **Unsupported**: no package manager or child processes |
+| Clipboard copy and image paste | Supported when a host clipboard is available | **Unsupported**: the VM has no host clipboard and native N-API clipboard binding | **Unsupported**: no host terminal clipboard |
+| Auto-update | Supported | **Unsupported** for the projected registry package; pass `--no-auto-update` | **Unsupported** |
+
+This Cloudflare column evaluates running the npm CLI directly in a standard Worker isolate with `nodejs_compat`. It does not describe an official Command Code Worker implementation—none was found—and it does not cover [Cloudflare Sandbox](https://developers.cloudflare.com/agents/tools/sandbox/), which is a separate container product with a real filesystem and shell.
+
+Sources: [Command Code CLI reference](https://commandcode.ai/docs/reference/cli), [headless mode](https://commandcode.ai/docs/core-concepts/headless), [MCP](https://commandcode.ai/docs/mcp), [skills](https://commandcode.ai/docs/skills), [hooks](https://commandcode.ai/docs/hooks), [Cloudflare Node.js compatibility](https://developers.cloudflare.com/workers/runtime-apis/nodejs/), and [Cloudflare Worker filesystem](https://developers.cloudflare.com/workers/runtime-apis/nodejs/fs/).
+
+## Permissions and updates
+
+`--yolo` lets Command Code edit files and run shell commands without its own prompts. Those operations remain subject to the VM's filesystem, process, network, and resource policies. Only use it with trusted prompts and least-privilege VM configuration.
+
+The registry package is immutable at `/opt/agentos`, so use `--no-auto-update` (or `COMMANDCODE_SKIP_UPDATES=1`) and update through a newer registry package instead.

--- a/website/public/docs/docs/agents/command-code.md
+++ b/website/public/docs/docs/agents/command-code.md
@@ -29,35 +29,35 @@ The opt-in network test installs the pinned `cmd-mod-hi@0.1.1` npm mod in a stan
 
 ## Runtime support matrix
 
-Legend: 🟢 **Supported** means the platform provides the required behavior and we are confident it works; 🟡 **Partial** identifies a concrete limitation or an important path that still needs validation; 🔴 **Unsupported** means the platform or deployment model cannot provide the behavior. Rows say when agentOS support was exercised end to end.
+Legend: 🟢 **Supported** means the platform provides the required behavior; notes identify any Command Code path that has not yet been exercised end to end. 🟡 **Partial** identifies a concrete platform limitation, not merely missing test coverage. 🔴 **Not implemented / unsupported** means the current implementation does not provide the behavior; it does not necessarily mean the behavior is impossible to add.
 
 | Command Code surface | Native Linux | agentOS VM | Direct Cloudflare Worker isolate |
 | --- | --- | --- | --- |
 | CLI startup, `--version`, `--help`, aliases | 🟢 Supported | 🟢 Supported — tested end to end | 🔴 Unsupported — no standalone Node CLI/process entrypoint |
 | API-key authentication | 🟢 Supported | 🟢 Supported — tested against the hosted service | 🔴 Unsupported as a full CLI |
-| Browser login / MCP OAuth browser flow | 🟢 Supported | 🟡 Partial — automatic host-browser opening is not validated; API keys are preferred | 🔴 Unsupported as a local CLI |
-| Interactive TUI and TTY input | 🟢 Supported | 🟡 Partial — terminal startup/help works; a funded interactive model turn is untested | 🔴 Unsupported — `node:tty`, `readline`, and REPL are non-functional stubs |
-| Headless `-p`, JSON/NDJSON, piped stdin, exit codes | 🟢 Supported | 🟡 Partial — authentication and the hosted billing boundary work; completed generation and streaming remain untested | 🔴 Unsupported as a full CLI |
+| Browser login / MCP OAuth browser flow | 🟢 Supported | 🟡 Partial — a VM cannot launch the host browser; use an API key or terminal URL/code flow | 🔴 Unsupported as a local CLI |
+| Interactive TUI and TTY input | 🟢 Supported | 🟢 Supported — terminal startup/help tested; a funded interactive model turn is untested | 🔴 Unsupported — `node:tty`, `readline`, and REPL are non-functional stubs |
+| Headless `-p`, JSON/NDJSON, piped stdin, exit codes | 🟢 Supported | 🟢 Supported — authentication and the hosted billing boundary tested; completed generation and streaming remain untested | 🔴 Unsupported as a full CLI |
 | Filesystem read/write and JS glob | 🟢 Supported | 🟢 Supported — backed by the VM VFS and Node `fs`/`fs.promises.glob`; VM policy still applies | 🔴 Unsupported for this CLI — no normal durable project tree |
-| Text search / ripgrep | 🟢 Supported | 🟡 Partial — install `@agentos-software/ripgrep`; a model-driven search is untested | 🔴 Unsupported for this CLI — Worker VFS has no glob APIs or normal project tree |
+| Text search / ripgrep | 🟢 Supported | 🟢 Supported — install `@agentos-software/ripgrep`; a Command Code model-driven search is untested | 🔴 Unsupported for this CLI — Worker VFS has no glob APIs or normal project tree |
 | Shell commands and hooks | 🟢 Supported (permission gated) | 🟢 Supported with the default `common` software bundle; VM process policy still applies | 🔴 Unsupported — `node:child_process` is a non-functional stub |
-| Git and managed worktrees | 🟢 Supported | 🟡 Partial — requires `@agentos-software/git`; Command Code's managed-worktree flow is untested | 🔴 Unsupported — no child processes or durable project filesystem |
+| Git and managed worktrees | 🟢 Supported | 🟢 Supported — install `@agentos-software/git`; Command Code's managed-worktree flow is untested | 🔴 Unsupported — no child processes or durable project filesystem |
 | Persisted sessions, resume, fork, rewind | 🟢 Supported | 🟢 Supported — session files live on the VM filesystem; durability follows the configured filesystem | 🔴 Unsupported — request-local VFS is not persistent |
 | Skills and `.agents/skills/` | 🟢 Supported | 🟢 Supported — project discovery/listing tested end to end | 🔴 Unsupported as a CLI |
 | MCP configuration | 🟢 Supported | 🟢 Supported — project-scoped HTTP add/get tested end to end | 🔴 Unsupported as a full CLI |
-| MCP HTTP/SSE tool use | 🟢 Supported | 🟡 Partial — the VM has HTTP/SSE networking, but a live MCP tool round trip is untested | 🔴 Unsupported as a full CLI, even though Workers can make HTTP requests |
-| MCP stdio servers | 🟢 Supported | 🟡 Partial — process support exists, but a Command Code stdio MCP round trip is untested | 🔴 Unsupported — no child processes |
+| MCP HTTP/SSE tool use | 🟢 Supported | 🟢 Supported — backed by VM HTTP/SSE networking; a live Command Code MCP tool round trip is untested | 🔴 Unsupported as a full CLI, even though Workers can make HTTP requests |
+| MCP stdio servers | 🟢 Supported | 🟢 Supported — backed by VM process and stdio support; a Command Code MCP round trip is untested | 🔴 Unsupported — no child processes |
 | Local TypeScript mods (`--mod`, local `mods add`) | 🟢 Supported | 🟢 Supported — install, compile, and discovery tested end to end | 🔴 Unsupported — no CLI process or persistent mod directory |
 | npm TypeScript mods | 🟢 Supported | 🟢 Supported — pinned registry install tested with the default `common` bundle | 🔴 Unsupported — no package manager or child processes |
-| Git-sourced mods | 🟢 Supported | 🟡 Partial — requires `@agentos-software/git`; this install path is untested | 🔴 Unsupported |
+| Git-sourced mods | 🟢 Supported | 🟢 Supported — install `@agentos-software/git`; this Command Code install path is untested | 🔴 Unsupported |
 | Mods with native Node add-ons | 🟡 Partial — only prebuilt add-ons can work because Command Code installs with `--ignore-scripts` | 🔴 Unsupported — VM Node execution does not load native Node add-ons | 🔴 Unsupported |
 | Clipboard copy and image paste | 🟢 Supported when a host clipboard is available | 🔴 Unsupported — the VM has no host clipboard or native N-API clipboard binding | 🔴 Unsupported — no host terminal clipboard |
 | Update checks (`cmd update --check-only`) | 🟢 Supported | 🟡 Partial — the upstream five-second npm version-query timeout can expire in a VM | 🔴 Unsupported as a CLI |
-| In-place auto/self-update | 🟢 Supported | 🔴 Unsupported by design — `/opt/agentos` packages are immutable; deploy a newer registry package instead | 🔴 Unsupported |
+| In-place auto/self-update | 🟢 Supported | 🔴 Not implemented — Command Code cannot replace the projected package in the current runtime | 🔴 Unsupported |
 
 This Cloudflare column evaluates running the npm CLI directly in a standard Worker isolate with `nodejs_compat`. It does not describe an official Command Code Worker implementation—none was found—and it does not cover [Cloudflare Sandbox](https://developers.cloudflare.com/agents/tools/sandbox/), which is a separate container product with a real filesystem and shell.
 
-Self-update is intentionally different from ordinary command support. `cmd update` replaces the globally installed npm package, while agentOS projects a content-addressed, read-only package at `/opt/agentos`. Mutating that projection would break reproducibility, so run with `--no-auto-update` and upgrade the agentOS registry package from the host. Mods install into writable user/project storage instead, which is why local and pure TypeScript npm mods work; npm-backed installation needs `sh`, while Git sources need Git and native Node add-ons cannot load in the VM.
+agentOS does not currently implement registry-mediated self-update. `cmd update` replaces a globally installed npm package, but it cannot replace the content-addressed, read-only package projected at `/opt/agentos`. A future host-mediated updater could select a newer registry package without mutating that projection; for now, run with `--no-auto-update` and upgrade the registry package from the host. Mods install into writable user/project storage instead, which is why local and pure TypeScript npm mods work; npm-backed installation needs `sh`, while Git sources need Git and native Node add-ons cannot load in the VM.
 
 Sources: [Command Code CLI reference](https://commandcode.ai/docs/reference/cli), [headless mode](https://commandcode.ai/docs/core-concepts/headless), [MCP](https://commandcode.ai/docs/mcp), [skills](https://commandcode.ai/docs/skills), [mods](https://commandcode.ai/docs/mods), [hooks](https://commandcode.ai/docs/hooks), [Cloudflare Node.js compatibility](https://developers.cloudflare.com/workers/runtime-apis/nodejs/), and [Cloudflare Worker filesystem](https://developers.cloudflare.com/workers/runtime-apis/nodejs/fs/).
 

--- a/website/src/content/docs/docs/agents/command-code.mdx
+++ b/website/src/content/docs/docs/agents/command-code.mdx
@@ -1,0 +1,68 @@
+---
+title: "Command Code CLI"
+description: "Run the genuine Command Code v1 CLI inside an agentOS VM."
+skill: false
+---
+
+## Quick start
+
+<CodeGroup>
+<CodeSnippet file="examples/command-code/server.ts" title="server.ts" />
+<CodeSnippet file="examples/command-code/client.ts" region="quickstart" title="client.ts" />
+</CodeGroup>
+
+The registry package projects `command-code@1.1.0` as `cmd`, `cmdc`, `command-code`, and `commandcode`. It uses the genuine upstream CLI, rebundled for the VM with compatibility patches recorded in the package's `agentos-build.json`. It is a command package, not an ACP agent. Invoke it with `execArgv` or attach a terminal for interactive use.
+
+The CLI is sourced from the npm release, whose package metadata is `UNLICENSED`; the public Command Code GitHub repository does not contain the CLI implementation. Review the upstream terms before publishing or redistributing the packed artifact.
+
+## Credentials
+
+Create a Command Code API key and pass it to the command as `COMMAND_CODE_API_KEY`, sourced from your server's environment. The credential stays inside the VM process environment and is read by the packaged Command Code CLI.
+
+See Command Code's [documentation](https://commandcode.ai/docs) for account and model details.
+
+## Verified command surface
+
+The agentOS end-to-end test runs the packaged command in a real VM and verifies:
+
+- version and help output;
+- unauthenticated status JSON and the documented headless authentication exit code;
+- `.agents/skills/` discovery with `cmd skills list --debug`;
+- project-scoped HTTP MCP add/get configuration and the resulting `.mcp.json`;
+- all four projected command aliases.
+
+The opt-in live test also verifies API-key authentication and reaches Command Code's hosted model endpoint. The available test key reached the billing boundary but had insufficient credits, so a complete generated model response has not been validated. Interactive help was also exercised through an agentOS terminal, but a complete interactive login and model turn has not been validated.
+
+## Runtime support matrix
+
+Legend: **Supported** is documented by Command Code on native Linux; **Tested** was exercised end to end in an agentOS VM; **Expected** has the required agentOS primitive but has not been exercised through an authenticated Command Code turn; **Partial** names an important limitation; **Unsupported** lacks the execution model the CLI requires.
+
+| Command Code surface | Native Linux | agentOS VM | Direct Cloudflare Worker isolate |
+| --- | --- | --- | --- |
+| CLI startup, `--version`, `--help`, aliases | Supported | **Tested** | **Unsupported**: no standalone Node CLI/process entrypoint |
+| API-key authentication | Supported | **Tested** with an opt-in live test | **Unsupported** as a full CLI |
+| Browser login / MCP OAuth browser flow | Supported | **Partial**: automatic host-browser opening is not validated; API keys are preferred | **Unsupported** as a local CLI |
+| Interactive TUI and TTY input | Supported | **Partial**: terminal startup/help tested; full interactive turn untested | **Unsupported**: `node:tty`, `readline`, and REPL are non-functional stubs |
+| Headless `-p`, JSON/NDJSON, piped stdin, exit codes | Supported | **Partial**: unauthenticated and authenticated billing boundaries tested; funded generation and streaming untested | **Unsupported** as a full CLI |
+| File read, grep, glob | Supported | **Expected**, not tested through a model turn | **Unsupported** for this CLI: Worker VFS has no glob APIs and no normal project tree |
+| File edit/write | Supported (permission gated) | **Expected**, subject to VM filesystem policy | **Unsupported** for a durable project: only request-local `/tmp` is writable |
+| Shell commands and hooks | Supported (permission gated) | **Expected**, subject to VM process policy; hook execution untested | **Unsupported**: `node:child_process` is a non-functional stub |
+| Git and managed worktrees | Supported | **Expected** when Git is installed; not tested with Command Code | **Unsupported**: no child processes or durable project filesystem |
+| Persisted sessions, resume, fork, rewind | Supported | **Expected** on the VM filesystem; not tested | **Unsupported**: request-local VFS is not persistent |
+| Skills and `.agents/skills/` | Supported | **Tested** for project discovery/listing | **Unsupported** as a CLI; bundled files alone do not provide the required process model |
+| MCP configuration | Supported | **Tested** for project-scoped HTTP add/get | **Unsupported** as a full CLI |
+| MCP HTTP/SSE tool use | Supported | **Expected**, subject to VM network policy; live server untested | **Unsupported** as a full CLI, even though Workers can make HTTP requests |
+| MCP stdio servers | Supported | **Expected**, subject to installed commands and process policy; untested | **Unsupported**: no child processes |
+| Mods and local package installation | Supported | **Partial**: not validated; native dependencies may require compatible agentOS software | **Unsupported**: no package manager or child processes |
+| Clipboard copy and image paste | Supported when a host clipboard is available | **Unsupported**: the VM has no host clipboard and native N-API clipboard binding | **Unsupported**: no host terminal clipboard |
+| Auto-update | Supported | **Unsupported** for the projected registry package; pass `--no-auto-update` | **Unsupported** |
+
+This Cloudflare column evaluates running the npm CLI directly in a standard Worker isolate with `nodejs_compat`. It does not describe an official Command Code Worker implementation—none was found—and it does not cover [Cloudflare Sandbox](https://developers.cloudflare.com/agents/tools/sandbox/), which is a separate container product with a real filesystem and shell.
+
+Sources: [Command Code CLI reference](https://commandcode.ai/docs/reference/cli), [headless mode](https://commandcode.ai/docs/core-concepts/headless), [MCP](https://commandcode.ai/docs/mcp), [skills](https://commandcode.ai/docs/skills), [hooks](https://commandcode.ai/docs/hooks), [Cloudflare Node.js compatibility](https://developers.cloudflare.com/workers/runtime-apis/nodejs/), and [Cloudflare Worker filesystem](https://developers.cloudflare.com/workers/runtime-apis/nodejs/fs/).
+
+## Permissions and updates
+
+`--yolo` lets Command Code edit files and run shell commands without its own prompts. Those operations remain subject to the VM's filesystem, process, network, and resource policies. Only use it with trusted prompts and least-privilege VM configuration.
+
+The registry package is immutable at `/opt/agentos`, so use `--no-auto-update` (or `COMMANDCODE_SKIP_UPDATES=1`) and update through a newer registry package instead.

--- a/website/src/content/docs/docs/agents/command-code.mdx
+++ b/website/src/content/docs/docs/agents/command-code.mdx
@@ -28,38 +28,45 @@ The agentOS end-to-end test runs the packaged command in a real VM and verifies:
 - version and help output;
 - unauthenticated status JSON and the documented headless authentication exit code;
 - `.agents/skills/` discovery with `cmd skills list --debug`;
+- local TypeScript mod installation and discovery with `cmd mods add` / `list`;
 - project-scoped HTTP MCP add/get configuration and the resulting `.mcp.json`;
 - all four projected command aliases.
 
-The opt-in live test also verifies API-key authentication and reaches Command Code's hosted model endpoint. The available test key reached the billing boundary but had insufficient credits, so a complete generated model response has not been validated. Interactive help was also exercised through an agentOS terminal, but a complete interactive login and model turn has not been validated.
+The opt-in network test installs the pinned `cmd-mod-hi@0.1.1` npm mod in a standard VM. npm-backed mods require the default `common` software bundle's `sh`; a minimal VM created with `defaultSoftware: false` must add `@agentos-software/coreutils`. The opt-in live test also verifies API-key authentication and reaches Command Code's hosted model endpoint. The available test key reached the billing boundary but had insufficient credits, so a complete generated model response has not been validated. Interactive help was also exercised through an agentOS terminal, but a complete interactive login and model turn has not been validated.
 
 ## Runtime support matrix
 
-Legend: **Supported** is documented by Command Code on native Linux; **Tested** was exercised end to end in an agentOS VM; **Expected** has the required agentOS primitive but has not been exercised through an authenticated Command Code turn; **Partial** names an important limitation; **Unsupported** lacks the execution model the CLI requires.
+Legend: 🟢 **Supported** means the platform provides the required behavior and we are confident it works; 🟡 **Partial** identifies a concrete limitation or an important path that still needs validation; 🔴 **Unsupported** means the platform or deployment model cannot provide the behavior. Rows say when agentOS support was exercised end to end.
 
 | Command Code surface | Native Linux | agentOS VM | Direct Cloudflare Worker isolate |
 | --- | --- | --- | --- |
-| CLI startup, `--version`, `--help`, aliases | Supported | **Tested** | **Unsupported**: no standalone Node CLI/process entrypoint |
-| API-key authentication | Supported | **Tested** with an opt-in live test | **Unsupported** as a full CLI |
-| Browser login / MCP OAuth browser flow | Supported | **Partial**: automatic host-browser opening is not validated; API keys are preferred | **Unsupported** as a local CLI |
-| Interactive TUI and TTY input | Supported | **Partial**: terminal startup/help tested; full interactive turn untested | **Unsupported**: `node:tty`, `readline`, and REPL are non-functional stubs |
-| Headless `-p`, JSON/NDJSON, piped stdin, exit codes | Supported | **Partial**: unauthenticated and authenticated billing boundaries tested; funded generation and streaming untested | **Unsupported** as a full CLI |
-| File read, grep, glob | Supported | **Expected**, not tested through a model turn | **Unsupported** for this CLI: Worker VFS has no glob APIs and no normal project tree |
-| File edit/write | Supported (permission gated) | **Expected**, subject to VM filesystem policy | **Unsupported** for a durable project: only request-local `/tmp` is writable |
-| Shell commands and hooks | Supported (permission gated) | **Expected**, subject to VM process policy; hook execution untested | **Unsupported**: `node:child_process` is a non-functional stub |
-| Git and managed worktrees | Supported | **Expected** when Git is installed; not tested with Command Code | **Unsupported**: no child processes or durable project filesystem |
-| Persisted sessions, resume, fork, rewind | Supported | **Expected** on the VM filesystem; not tested | **Unsupported**: request-local VFS is not persistent |
-| Skills and `.agents/skills/` | Supported | **Tested** for project discovery/listing | **Unsupported** as a CLI; bundled files alone do not provide the required process model |
-| MCP configuration | Supported | **Tested** for project-scoped HTTP add/get | **Unsupported** as a full CLI |
-| MCP HTTP/SSE tool use | Supported | **Expected**, subject to VM network policy; live server untested | **Unsupported** as a full CLI, even though Workers can make HTTP requests |
-| MCP stdio servers | Supported | **Expected**, subject to installed commands and process policy; untested | **Unsupported**: no child processes |
-| Mods and local package installation | Supported | **Partial**: not validated; native dependencies may require compatible agentOS software | **Unsupported**: no package manager or child processes |
-| Clipboard copy and image paste | Supported when a host clipboard is available | **Unsupported**: the VM has no host clipboard and native N-API clipboard binding | **Unsupported**: no host terminal clipboard |
-| Auto-update | Supported | **Unsupported** for the projected registry package; pass `--no-auto-update` | **Unsupported** |
+| CLI startup, `--version`, `--help`, aliases | 🟢 Supported | 🟢 Supported — tested end to end | 🔴 Unsupported — no standalone Node CLI/process entrypoint |
+| API-key authentication | 🟢 Supported | 🟢 Supported — tested against the hosted service | 🔴 Unsupported as a full CLI |
+| Browser login / MCP OAuth browser flow | 🟢 Supported | 🟡 Partial — automatic host-browser opening is not validated; API keys are preferred | 🔴 Unsupported as a local CLI |
+| Interactive TUI and TTY input | 🟢 Supported | 🟡 Partial — terminal startup/help works; a funded interactive model turn is untested | 🔴 Unsupported — `node:tty`, `readline`, and REPL are non-functional stubs |
+| Headless `-p`, JSON/NDJSON, piped stdin, exit codes | 🟢 Supported | 🟡 Partial — authentication and the hosted billing boundary work; completed generation and streaming remain untested | 🔴 Unsupported as a full CLI |
+| Filesystem read/write and JS glob | 🟢 Supported | 🟢 Supported — backed by the VM VFS and Node `fs`/`fs.promises.glob`; VM policy still applies | 🔴 Unsupported for this CLI — no normal durable project tree |
+| Text search / ripgrep | 🟢 Supported | 🟡 Partial — install `@agentos-software/ripgrep`; a model-driven search is untested | 🔴 Unsupported for this CLI — Worker VFS has no glob APIs or normal project tree |
+| Shell commands and hooks | 🟢 Supported (permission gated) | 🟢 Supported with the default `common` software bundle; VM process policy still applies | 🔴 Unsupported — `node:child_process` is a non-functional stub |
+| Git and managed worktrees | 🟢 Supported | 🟡 Partial — requires `@agentos-software/git`; Command Code's managed-worktree flow is untested | 🔴 Unsupported — no child processes or durable project filesystem |
+| Persisted sessions, resume, fork, rewind | 🟢 Supported | 🟢 Supported — session files live on the VM filesystem; durability follows the configured filesystem | 🔴 Unsupported — request-local VFS is not persistent |
+| Skills and `.agents/skills/` | 🟢 Supported | 🟢 Supported — project discovery/listing tested end to end | 🔴 Unsupported as a CLI |
+| MCP configuration | 🟢 Supported | 🟢 Supported — project-scoped HTTP add/get tested end to end | 🔴 Unsupported as a full CLI |
+| MCP HTTP/SSE tool use | 🟢 Supported | 🟡 Partial — the VM has HTTP/SSE networking, but a live MCP tool round trip is untested | 🔴 Unsupported as a full CLI, even though Workers can make HTTP requests |
+| MCP stdio servers | 🟢 Supported | 🟡 Partial — process support exists, but a Command Code stdio MCP round trip is untested | 🔴 Unsupported — no child processes |
+| Local TypeScript mods (`--mod`, local `mods add`) | 🟢 Supported | 🟢 Supported — install, compile, and discovery tested end to end | 🔴 Unsupported — no CLI process or persistent mod directory |
+| npm TypeScript mods | 🟢 Supported | 🟢 Supported — pinned registry install tested with the default `common` bundle | 🔴 Unsupported — no package manager or child processes |
+| Git-sourced mods | 🟢 Supported | 🟡 Partial — requires `@agentos-software/git`; this install path is untested | 🔴 Unsupported |
+| Mods with native Node add-ons | 🟡 Partial — only prebuilt add-ons can work because Command Code installs with `--ignore-scripts` | 🔴 Unsupported — VM Node execution does not load native Node add-ons | 🔴 Unsupported |
+| Clipboard copy and image paste | 🟢 Supported when a host clipboard is available | 🔴 Unsupported — the VM has no host clipboard or native N-API clipboard binding | 🔴 Unsupported — no host terminal clipboard |
+| Update checks (`cmd update --check-only`) | 🟢 Supported | 🟡 Partial — the upstream five-second npm version-query timeout can expire in a VM | 🔴 Unsupported as a CLI |
+| In-place auto/self-update | 🟢 Supported | 🔴 Unsupported by design — `/opt/agentos` packages are immutable; deploy a newer registry package instead | 🔴 Unsupported |
 
 This Cloudflare column evaluates running the npm CLI directly in a standard Worker isolate with `nodejs_compat`. It does not describe an official Command Code Worker implementation—none was found—and it does not cover [Cloudflare Sandbox](https://developers.cloudflare.com/agents/tools/sandbox/), which is a separate container product with a real filesystem and shell.
 
-Sources: [Command Code CLI reference](https://commandcode.ai/docs/reference/cli), [headless mode](https://commandcode.ai/docs/core-concepts/headless), [MCP](https://commandcode.ai/docs/mcp), [skills](https://commandcode.ai/docs/skills), [hooks](https://commandcode.ai/docs/hooks), [Cloudflare Node.js compatibility](https://developers.cloudflare.com/workers/runtime-apis/nodejs/), and [Cloudflare Worker filesystem](https://developers.cloudflare.com/workers/runtime-apis/nodejs/fs/).
+Self-update is intentionally different from ordinary command support. `cmd update` replaces the globally installed npm package, while agentOS projects a content-addressed, read-only package at `/opt/agentos`. Mutating that projection would break reproducibility, so run with `--no-auto-update` and upgrade the agentOS registry package from the host. Mods install into writable user/project storage instead, which is why local and pure TypeScript npm mods work; npm-backed installation needs `sh`, while Git sources need Git and native Node add-ons cannot load in the VM.
+
+Sources: [Command Code CLI reference](https://commandcode.ai/docs/reference/cli), [headless mode](https://commandcode.ai/docs/core-concepts/headless), [MCP](https://commandcode.ai/docs/mcp), [skills](https://commandcode.ai/docs/skills), [mods](https://commandcode.ai/docs/mods), [hooks](https://commandcode.ai/docs/hooks), [Cloudflare Node.js compatibility](https://developers.cloudflare.com/workers/runtime-apis/nodejs/), and [Cloudflare Worker filesystem](https://developers.cloudflare.com/workers/runtime-apis/nodejs/fs/).
 
 ## Permissions and updates
 

--- a/website/src/content/docs/docs/agents/command-code.mdx
+++ b/website/src/content/docs/docs/agents/command-code.mdx
@@ -36,35 +36,35 @@ The opt-in network test installs the pinned `cmd-mod-hi@0.1.1` npm mod in a stan
 
 ## Runtime support matrix
 
-Legend: 🟢 **Supported** means the platform provides the required behavior and we are confident it works; 🟡 **Partial** identifies a concrete limitation or an important path that still needs validation; 🔴 **Unsupported** means the platform or deployment model cannot provide the behavior. Rows say when agentOS support was exercised end to end.
+Legend: 🟢 **Supported** means the platform provides the required behavior; notes identify any Command Code path that has not yet been exercised end to end. 🟡 **Partial** identifies a concrete platform limitation, not merely missing test coverage. 🔴 **Not implemented / unsupported** means the current implementation does not provide the behavior; it does not necessarily mean the behavior is impossible to add.
 
 | Command Code surface | Native Linux | agentOS VM | Direct Cloudflare Worker isolate |
 | --- | --- | --- | --- |
 | CLI startup, `--version`, `--help`, aliases | 🟢 Supported | 🟢 Supported — tested end to end | 🔴 Unsupported — no standalone Node CLI/process entrypoint |
 | API-key authentication | 🟢 Supported | 🟢 Supported — tested against the hosted service | 🔴 Unsupported as a full CLI |
-| Browser login / MCP OAuth browser flow | 🟢 Supported | 🟡 Partial — automatic host-browser opening is not validated; API keys are preferred | 🔴 Unsupported as a local CLI |
-| Interactive TUI and TTY input | 🟢 Supported | 🟡 Partial — terminal startup/help works; a funded interactive model turn is untested | 🔴 Unsupported — `node:tty`, `readline`, and REPL are non-functional stubs |
-| Headless `-p`, JSON/NDJSON, piped stdin, exit codes | 🟢 Supported | 🟡 Partial — authentication and the hosted billing boundary work; completed generation and streaming remain untested | 🔴 Unsupported as a full CLI |
+| Browser login / MCP OAuth browser flow | 🟢 Supported | 🟡 Partial — a VM cannot launch the host browser; use an API key or terminal URL/code flow | 🔴 Unsupported as a local CLI |
+| Interactive TUI and TTY input | 🟢 Supported | 🟢 Supported — terminal startup/help tested; a funded interactive model turn is untested | 🔴 Unsupported — `node:tty`, `readline`, and REPL are non-functional stubs |
+| Headless `-p`, JSON/NDJSON, piped stdin, exit codes | 🟢 Supported | 🟢 Supported — authentication and the hosted billing boundary tested; completed generation and streaming remain untested | 🔴 Unsupported as a full CLI |
 | Filesystem read/write and JS glob | 🟢 Supported | 🟢 Supported — backed by the VM VFS and Node `fs`/`fs.promises.glob`; VM policy still applies | 🔴 Unsupported for this CLI — no normal durable project tree |
-| Text search / ripgrep | 🟢 Supported | 🟡 Partial — install `@agentos-software/ripgrep`; a model-driven search is untested | 🔴 Unsupported for this CLI — Worker VFS has no glob APIs or normal project tree |
+| Text search / ripgrep | 🟢 Supported | 🟢 Supported — install `@agentos-software/ripgrep`; a Command Code model-driven search is untested | 🔴 Unsupported for this CLI — Worker VFS has no glob APIs or normal project tree |
 | Shell commands and hooks | 🟢 Supported (permission gated) | 🟢 Supported with the default `common` software bundle; VM process policy still applies | 🔴 Unsupported — `node:child_process` is a non-functional stub |
-| Git and managed worktrees | 🟢 Supported | 🟡 Partial — requires `@agentos-software/git`; Command Code's managed-worktree flow is untested | 🔴 Unsupported — no child processes or durable project filesystem |
+| Git and managed worktrees | 🟢 Supported | 🟢 Supported — install `@agentos-software/git`; Command Code's managed-worktree flow is untested | 🔴 Unsupported — no child processes or durable project filesystem |
 | Persisted sessions, resume, fork, rewind | 🟢 Supported | 🟢 Supported — session files live on the VM filesystem; durability follows the configured filesystem | 🔴 Unsupported — request-local VFS is not persistent |
 | Skills and `.agents/skills/` | 🟢 Supported | 🟢 Supported — project discovery/listing tested end to end | 🔴 Unsupported as a CLI |
 | MCP configuration | 🟢 Supported | 🟢 Supported — project-scoped HTTP add/get tested end to end | 🔴 Unsupported as a full CLI |
-| MCP HTTP/SSE tool use | 🟢 Supported | 🟡 Partial — the VM has HTTP/SSE networking, but a live MCP tool round trip is untested | 🔴 Unsupported as a full CLI, even though Workers can make HTTP requests |
-| MCP stdio servers | 🟢 Supported | 🟡 Partial — process support exists, but a Command Code stdio MCP round trip is untested | 🔴 Unsupported — no child processes |
+| MCP HTTP/SSE tool use | 🟢 Supported | 🟢 Supported — backed by VM HTTP/SSE networking; a live Command Code MCP tool round trip is untested | 🔴 Unsupported as a full CLI, even though Workers can make HTTP requests |
+| MCP stdio servers | 🟢 Supported | 🟢 Supported — backed by VM process and stdio support; a Command Code MCP round trip is untested | 🔴 Unsupported — no child processes |
 | Local TypeScript mods (`--mod`, local `mods add`) | 🟢 Supported | 🟢 Supported — install, compile, and discovery tested end to end | 🔴 Unsupported — no CLI process or persistent mod directory |
 | npm TypeScript mods | 🟢 Supported | 🟢 Supported — pinned registry install tested with the default `common` bundle | 🔴 Unsupported — no package manager or child processes |
-| Git-sourced mods | 🟢 Supported | 🟡 Partial — requires `@agentos-software/git`; this install path is untested | 🔴 Unsupported |
+| Git-sourced mods | 🟢 Supported | 🟢 Supported — install `@agentos-software/git`; this Command Code install path is untested | 🔴 Unsupported |
 | Mods with native Node add-ons | 🟡 Partial — only prebuilt add-ons can work because Command Code installs with `--ignore-scripts` | 🔴 Unsupported — VM Node execution does not load native Node add-ons | 🔴 Unsupported |
 | Clipboard copy and image paste | 🟢 Supported when a host clipboard is available | 🔴 Unsupported — the VM has no host clipboard or native N-API clipboard binding | 🔴 Unsupported — no host terminal clipboard |
 | Update checks (`cmd update --check-only`) | 🟢 Supported | 🟡 Partial — the upstream five-second npm version-query timeout can expire in a VM | 🔴 Unsupported as a CLI |
-| In-place auto/self-update | 🟢 Supported | 🔴 Unsupported by design — `/opt/agentos` packages are immutable; deploy a newer registry package instead | 🔴 Unsupported |
+| In-place auto/self-update | 🟢 Supported | 🔴 Not implemented — Command Code cannot replace the projected package in the current runtime | 🔴 Unsupported |
 
 This Cloudflare column evaluates running the npm CLI directly in a standard Worker isolate with `nodejs_compat`. It does not describe an official Command Code Worker implementation—none was found—and it does not cover [Cloudflare Sandbox](https://developers.cloudflare.com/agents/tools/sandbox/), which is a separate container product with a real filesystem and shell.
 
-Self-update is intentionally different from ordinary command support. `cmd update` replaces the globally installed npm package, while agentOS projects a content-addressed, read-only package at `/opt/agentos`. Mutating that projection would break reproducibility, so run with `--no-auto-update` and upgrade the agentOS registry package from the host. Mods install into writable user/project storage instead, which is why local and pure TypeScript npm mods work; npm-backed installation needs `sh`, while Git sources need Git and native Node add-ons cannot load in the VM.
+agentOS does not currently implement registry-mediated self-update. `cmd update` replaces a globally installed npm package, but it cannot replace the content-addressed, read-only package projected at `/opt/agentos`. A future host-mediated updater could select a newer registry package without mutating that projection; for now, run with `--no-auto-update` and upgrade the registry package from the host. Mods install into writable user/project storage instead, which is why local and pure TypeScript npm mods work; npm-backed installation needs `sh`, while Git sources need Git and native Node add-ons cannot load in the VM.
 
 Sources: [Command Code CLI reference](https://commandcode.ai/docs/reference/cli), [headless mode](https://commandcode.ai/docs/core-concepts/headless), [MCP](https://commandcode.ai/docs/mcp), [skills](https://commandcode.ai/docs/skills), [mods](https://commandcode.ai/docs/mods), [hooks](https://commandcode.ai/docs/hooks), [Cloudflare Node.js compatibility](https://developers.cloudflare.com/workers/runtime-apis/nodejs/), and [Cloudflare Worker filesystem](https://developers.cloudflare.com/workers/runtime-apis/nodejs/fs/).
 

--- a/website/src/generated/registry.json
+++ b/website/src/generated/registry.json
@@ -129,6 +129,19 @@
 			"image": "/images/registry/jq.svg"
 		},
 		{
+			"slug": "command-code",
+			"title": "Command Code",
+			"description": "Command Code v1 coding-agent CLI.",
+			"types": [
+				"software"
+			],
+			"category": "agents",
+			"priority": 75,
+			"package": "@agentos-software/command-code",
+			"status": "docs",
+			"docsHref": "/docs/agents/command-code"
+		},
+		{
 			"slug": "sqlite3",
 			"title": "SQLite3",
 			"description": "SQLite database command-line interface.",

--- a/website/src/generated/routes.json
+++ b/website/src/generated/routes.json
@@ -152,6 +152,10 @@
       "title": "Codex",
       "description": "Run the Codex coding agent inside a VM with skills, MCP servers, and custom configuration."
     },
+    "/docs/docs/agents/command-code": {
+      "title": "Command Code CLI",
+      "description": "Run the genuine Command Code v1 CLI inside an agentOS VM."
+    },
     "/docs/docs/agents/custom": {
       "title": "Custom Agents",
       "description": "Bring your own coding agent to agentOS by speaking the Agent Client Protocol (ACP) inside the VM."
@@ -212,10 +216,6 @@
       "title": "TLS & SSL",
       "description": "How agentOS uses in-guest mbedTLS plus a VM CA bundle for curl / wget / git, and a hermetic OpenSSL libcrypto build for OpenSSH."
     },
-    "/docs/docs/frameworks/vercel-eve": {
-      "title": "Vercel Eve",
-      "description": "Run Vercel Eve with agentOS and Rivet World."
-    },
     "/docs/docs/custom-software/building-wasm": {
       "title": "Building Binaries",
       "description": "Compile WASM command binaries for agentOS from source."
@@ -227,6 +227,10 @@
     "/docs/docs/custom-software/publishing": {
       "title": "Publishing Packages",
       "description": "Build, publish, and consume agentOS packages — locally, from npm, or from your own repo."
+    },
+    "/docs/docs/frameworks/vercel-eve": {
+      "title": "Vercel Eve",
+      "description": "Run Vercel Eve with agentOS and Rivet World."
     }
   }
 }


### PR DESCRIPTION
## Summary

- package the genuine `command-code@1.1.0` CLI as a command-only agentOS registry package with all four upstream aliases; ACP remains out of scope
- close the Node compatibility gaps required by the CLI, including named `fs/promises.glob`, blank console lines, and uncatchable synchronous/async `process.exit()`
- add a runnable example, VM end-to-end coverage, and a green/yellow/red Native Linux vs agentOS vs direct Cloudflare Worker support matrix
- verify local TypeScript and pinned npm mod installation end to end, and document the current self-update limitation
- document that the upstream npm artifact is marked `UNLICENSED` and requires redistribution review

## Validation

- package build, package tests, example typecheck, and focused VM tests pass
- local TypeScript mod install passes in a minimal VM; pinned npm mod install passes in a standard VM with the default common software
- authenticated live test accepts the API key and reaches the hosted model boundary; the tested account had insufficient credits for a completed generation
- Rust checks and formatting pass for the affected runtime crates
- website production build passes and the live docs page renders the colored matrix
- workspace-wide `pnpm check-types` remains blocked by the existing missing Codex WASI artifact prerequisite
- current required CI also fails on `main` for unrelated Codex artifact, clippy, and benchmark-gate issues