### PR TITLE
fix(agentos-apps): read the pack artifact over the VM API instead of a host_dir mount

### DIFF
--- a/packages/agentos-apps/src/actors.ts
+++ b/packages/agentos-apps/src/actors.ts
@@ -1,5 +1,5 @@
 import { createHash, randomUUID, timingSafeEqual } from "node:crypto";
-import { mkdtemp, open, readFile, rm, stat } from "node:fs/promises";
+import { mkdtemp, open, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -18,7 +18,6 @@ import {
 import {
 	AgentOs,
 	type AgentOsOptions,
-	createHostDirBackend,
 } from "@rivet-dev/agentos-core";
 import { packAospkgFromTarBytes } from "@rivet-dev/agentos-toolchain";
 import { actor, UserError } from "rivetkit";
@@ -3131,52 +3130,27 @@ export function createAppsActors(
 		},
 	};
 	const createBuildVm = async (): Promise<BuildHandle> => {
-		const outputDirectory = await mkdtemp(
-			join(tmpdir(), "agentos-apps-build-output-"),
-		);
-		const artifactGuestPath = "/agentos-app-output/agentos-app.tar";
-		const artifactHostPath = join(outputDirectory, "agentos-app.tar");
-		let vm: AgentOs;
-		try {
-			vm = await AgentOs.create({
-				...buildVmOptions,
-				mounts: [
-					...(buildVmOptions.mounts ?? []),
-					{
-						path: "/agentos-app-output",
-						readOnly: false,
-						plugin: createHostDirBackend({
-							hostPath: outputDirectory,
-							readOnly: false,
-						}),
-					},
-				],
-			});
-		} catch (error) {
-			await rm(outputDirectory, { recursive: true, force: true });
-			throw error;
-		}
+		// The artifact stays on the guest filesystem and is read back over the
+		// host VM API instead of a writable host_dir mount: guest-side access
+		// to host_dir mounts fails with "Permission denied (os error 2)"
+		// (rivet-dev/agentos#1872), which made every pack step fail. Reading
+		// through vm.readFile also removes the host temp directory and its
+		// cleanup entirely.
+		const artifactGuestPath = "/agentos-app.tar";
+		const vm = await AgentOs.create(buildVmOptions);
+		let artifact: Uint8Array | undefined;
+		const readArtifact = async (): Promise<Uint8Array> => {
+			artifact ??= new Uint8Array(await vm.readFile(artifactGuestPath));
+			return artifact;
+		};
 		return {
 			artifactGuestPath,
 			writeFiles: (...args) => vm.writeFiles(...args),
 			execArgv: (...args) => vm.execArgv(...args),
-			artifactSize: async () => (await stat(artifactHostPath)).size,
-			readArtifact: async () =>
-				new Uint8Array(await readFile(artifactHostPath)),
+			artifactSize: async () => (await readArtifact()).byteLength,
+			readArtifact,
 			dispose: async () => {
-				const results = await Promise.allSettled([
-					vm.dispose(),
-					rm(outputDirectory, { recursive: true, force: true }),
-				]);
-				const failures = results.flatMap((result) =>
-					result.status === "rejected" ? [result.reason] : [],
-				);
-				if (failures.length > 0) {
-					throw new AggregateError(
-						failures,
-						"failed to dispose AgentOS Apps build VM output",
-					);
-				}
+				await vm.dispose();
 			},
 		};
 	};


### PR DESCRIPTION
Fixes the `deployApp()` side of #1872.

## Problem

Guest-side access to `host_dir` mounts fails with `Permission denied (os
error 2)` in 0.2.14 — reads and writes, macOS and Linux (minimal repro:
https://github.com/tobowers/agentos-hostdir-repro). The apps pack step runs
guest `tar -cf` into a writable host_dir mount, so every deploy fails with
`agentos_apps_pack_failed`:

```text
RivetError: tar failed with exit code 1
metadata: { exitCode: 1, stderr: "tar: Permission denied (os error 2)\n" }
```

## Change

`createBuildVm` no longer mounts a host output directory. `tar` writes the
artifact to the guest filesystem (`/agentos-app.tar`, outside `/release` so
it never packs itself) and the host reads it back with `vm.readFile`, which
works correctly. The artifact is read once and cached so `artifactSize` and
`readArtifact` don't fetch it twice. This also removes the host temp
directory, its error-path cleanup, and the dispose-time `rm` from the build
path — one less moving part even after the underlying host_dir bug is fixed.

Verified end to end against 0.2.14 (as a dist patch of this same change) on
macOS arm64 and Linux arm64: hono-only deploys, rivetkit-dependency deploys,
release caching, and failed-build release preservation all behave as before;
only the pack step's transport changed.

## Consideration for review

`vm.readFile` transports the whole artifact over the sidecar bridge in one
call. If bridge read limits cap this below `maxBuildArtifactBytes` for large
releases, the read may need chunking — happy to adjust if you have a
preferred primitive for large guest reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
