### PR TITLE
fix(runtime): atob WHATWG base64

### DIFF
--- a/crates/native-sidecar/tests/builtin_conformance.rs
+++ b/crates/native-sidecar/tests/builtin_conformance.rs
@@ -69,6 +69,7 @@ const BUILTIN_CONFORMANCE_CASES: &[&str] = &[
     "events",
     "stream",
     "buffer",
+    "global_base64",
     "url",
     "stdlib_polyfill",
     "web_streams",
@@ -3834,6 +3835,39 @@ fn buffer_concat_truncation_matches_host_node() {
     run_isolated_builtin_conformance_test("buffer-concat-truncation");
 }
 
+fn global_base64_conformance_matches_host_node() {
+    assert_conformance(
+        "global_base64",
+        r#"
+function describeError(callback) {
+  try {
+    callback();
+    return { threw: false };
+  } catch (error) {
+    return {
+      threw: true,
+      name: error?.name ?? null,
+      code: error?.code ?? null,
+      message: error?.message ?? null,
+    };
+  }
+}
+
+console.log(JSON.stringify({
+  atobText: atob("aGVsbG8="),
+  atobWhitespace: atob(" YQ== \n"),
+  atobNumberCoercion: atob(1234),
+  btoaText: btoa("hello"),
+  btoaNumberCoercion: btoa(1234),
+  invalidAtob: describeError(() => atob("%%%")),
+  invalidUrlSafeDashAtob: describeError(() => atob("AA-A")),
+  invalidUrlSafeUnderscoreAtob: describeError(() => atob("AA_A")),
+  invalidBtoa: describeError(() => btoa("✓")),
+}));
+"#,
+    );
+}
+
 fn mkdtemp_sync_collision_safe_matches_host_node_impl() {
     let cwd = temp_dir("mkdtemp-sync-collision-safe");
     let entrypoint = cwd.join("entry.mjs");
@@ -4874,6 +4908,7 @@ fn run_named_case(case_name: &str) {
         "events" => events_conformance_matches_host_node(),
         "stream" => stream_conformance_matches_host_node(),
         "buffer" => buffer_conformance_matches_host_node(),
+        "global_base64" => global_base64_conformance_matches_host_node(),
         "url" => url_conformance_matches_host_node(),
         "stdlib_polyfill" => stdlib_polyfill_conformance_matches_host_node(),
         "web_streams" => web_streams_conformance_matches_host_node(),

--- a/crates/native-sidecar/tests/builtin_conformance.rs
+++ b/crates/native-sidecar/tests/builtin_conformance.rs
@@ -3855,11 +3855,15 @@ function describeError(callback) {
 
 console.log(JSON.stringify({
   atobText: atob("aGVsbG8="),
+  atobUnpaddedSingleByte: atob("YQ"),
+  atobUnpaddedTwoBytes: atob("YWI"),
   atobWhitespace: atob(" YQ== \n"),
   atobNumberCoercion: atob(1234),
   btoaText: btoa("hello"),
   btoaNumberCoercion: btoa(1234),
   invalidAtob: describeError(() => atob("%%%")),
+  invalidShortAtob: describeError(() => atob("Y")),
+  invalidPaddingAtob: describeError(() => atob("AA=A")),
   invalidUrlSafeDashAtob: describeError(() => atob("AA-A")),
   invalidUrlSafeUnderscoreAtob: describeError(() => atob("AA_A")),
   invalidBtoa: describeError(() => btoa("✓")),

--- a/crates/native-sidecar/tests/builtin_conformance.rs
+++ b/crates/native-sidecar/tests/builtin_conformance.rs
@@ -3864,6 +3864,8 @@ console.log(JSON.stringify({
   invalidAtob: describeError(() => atob("%%%")),
   invalidShortAtob: describeError(() => atob("Y")),
   invalidPaddingAtob: describeError(() => atob("AA=A")),
+  invalidPartialPaddingAtob: describeError(() => atob("YQ=")),
+  invalidOnlyPaddingAtob: describeError(() => atob("==")),
   invalidUrlSafeDashAtob: describeError(() => atob("AA-A")),
   invalidUrlSafeUnderscoreAtob: describeError(() => atob("AA_A")),
   invalidBtoa: describeError(() => btoa("✓")),

--- a/packages/build-tools/bridge-src/builtins/process.ts
+++ b/packages/build-tools/bridge-src/builtins/process.ts
@@ -1176,6 +1176,7 @@ function setupGlobals() {
         // implements RFC 4648 section 4 instead, so normalize the input and
         // reject URL-safe characters before handing it over.
         const input = String(value).replace(/[\t\n\f\r ]+/g, "");
+        const hasPadding = input.includes("=");
         if (/[^A-Za-z0-9+/=]/.test(input) || /={3,}/.test(input) || /=[^=]/.test(input)) {
           throw createInvalidCharacterError();
         }
@@ -1183,7 +1184,10 @@ function setupGlobals() {
         if (remainder === 1) {
           throw createInvalidCharacterError("The string to be decoded is not correctly encoded.");
         }
-        const normalizedInput = remainder === 2 ? `${input}==` : remainder === 3 ? `${input}=` : input;
+        if (hasPadding && remainder !== 0) {
+          throw createInvalidCharacterError();
+        }
+        const normalizedInput = !hasPadding && remainder === 2 ? `${input}==` : !hasPadding && remainder === 3 ? `${input}=` : input;
         let bytes = new Uint8Array(0);
         try {
           bytes = base64.toByteArray(normalizedInput);

--- a/packages/build-tools/bridge-src/builtins/process.ts
+++ b/packages/build-tools/bridge-src/builtins/process.ts
@@ -1141,6 +1141,9 @@ function setupGlobals() {
   g.Event = Event;
   g.CustomEvent = CustomEvent;
   g.EventTarget = EventTarget;
+  if (typeof g.DOMException === "undefined") {
+    g.DOMException = SandboxDOMException;
+  }
   if (typeof g.Buffer === "undefined") {
     g.Buffer = Buffer3;
   }
@@ -1161,9 +1164,23 @@ function setupGlobals() {
   installBuiltinUtilFormatWithOptions(builtinUtilModule);
   if (typeof g.atob === "undefined" || typeof g.btoa === "undefined") {
     const base64 = require_base64_js();
+    const createInvalidCharacterError = () => {
+      const error = new g.DOMException("Invalid character", "InvalidCharacterError");
+      if (error.code === 0) error.code = 5;
+      return error;
+    };
     if (typeof g.atob === "undefined") {
       g.atob = (value) => {
-        const bytes = base64.toByteArray(String(value));
+        const input = String(value).replace(/[\t\n\f\r ]+/g, "");
+        if (/[^A-Za-z0-9+/=]/.test(input)) {
+          throw createInvalidCharacterError();
+        }
+        let bytes = new Uint8Array(0);
+        try {
+          bytes = base64.toByteArray(input);
+        } catch {
+          throw createInvalidCharacterError();
+        }
         let decoded = "";
         for (const byte of bytes) {
           decoded += String.fromCharCode(byte);
@@ -1178,7 +1195,7 @@ function setupGlobals() {
         for (let index = 0; index < input.length; index += 1) {
           const code = input.charCodeAt(index);
           if (code > 255) {
-            throw new TypeError("Invalid character");
+            throw createInvalidCharacterError();
           }
           bytes[index] = code;
         }
@@ -1194,9 +1211,6 @@ function setupGlobals() {
   }
   if (typeof g.CryptoKey === "undefined") {
     g.CryptoKey = SandboxCryptoKey;
-  }
-  if (typeof g.DOMException === "undefined") {
-    g.DOMException = SandboxDOMException;
   }
   if (typeof g.crypto === "undefined") {
     g.crypto = builtinCryptoModule;

--- a/packages/build-tools/bridge-src/builtins/process.ts
+++ b/packages/build-tools/bridge-src/builtins/process.ts
@@ -1164,20 +1164,29 @@ function setupGlobals() {
   installBuiltinUtilFormatWithOptions(builtinUtilModule);
   if (typeof g.atob === "undefined" || typeof g.btoa === "undefined") {
     const base64 = require_base64_js();
-    const createInvalidCharacterError = () => {
-      const error = new g.DOMException("Invalid character", "InvalidCharacterError");
+    const createInvalidCharacterError = (message = "Invalid character") => {
+      const error = new g.DOMException(message, "InvalidCharacterError");
       if (error.code === 0) error.code = 5;
       return error;
     };
     if (typeof g.atob === "undefined") {
       g.atob = (value) => {
+        // WHATWG forgiving-base64 decode accepts ASCII whitespace and
+        // unpadded input, but rejects the base64url alphabet. base64-js
+        // implements RFC 4648 section 4 instead, so normalize the input and
+        // reject URL-safe characters before handing it over.
         const input = String(value).replace(/[\t\n\f\r ]+/g, "");
-        if (/[^A-Za-z0-9+/=]/.test(input)) {
+        if (/[^A-Za-z0-9+/=]/.test(input) || /={3,}/.test(input) || /=[^=]/.test(input)) {
           throw createInvalidCharacterError();
         }
+        const remainder = input.length % 4;
+        if (remainder === 1) {
+          throw createInvalidCharacterError("The string to be decoded is not correctly encoded.");
+        }
+        const normalizedInput = remainder === 2 ? `${input}==` : remainder === 3 ? `${input}=` : input;
         let bytes = new Uint8Array(0);
         try {
-          bytes = base64.toByteArray(input);
+          bytes = base64.toByteArray(normalizedInput);
         } catch {
           throw createInvalidCharacterError();
         }


### PR DESCRIPTION
## What

- Align fallback `atob` / `btoa` behavior with Node/Web globals.
- Normalize WHATWG forgiving-base64 input before passing it to `base64-js`.
- Reject base64url alphabet characters (`-`, `_`) for `atob`.
- Preserve `InvalidCharacterError` shape, including legacy `code = 5`.
- Add native-sidecar conformance coverage for padded, unpadded, whitespace, invalid padding, base64url, and `btoa` invalid-character cases.

## Impact

I hit this building an app on `@rivet-dev/agentos` 0.2.14 (macOS arm64) that runs the
`pi` agent (`@agentos-software/pi`) inside a VM with the `openai-codex` provider.
**Every prompt failed**, with the agent returning a single opaque line:

> Failed to extract accountId from token

The credentials were fine. The same `~/.pi/agent/auth.json` works when I run pi directly
on the host; inside the VM the token is intact (not expired, `chatgpt_account_id` claim
present) — I verified that by reading the file back out of the VM. The agent is simply
unable to decode it.

The failing path: pi decodes its OAuth access token on every request to derive the
`chatgpt-account-id` header, using `atob(token.split(".")[1])`. Per RFC 7515 §2, JWT
segments are base64url **with padding stripped**, so that payload's length is rarely a
multiple of 4 (mine: 1351 bytes, `% 4 === 3`).

This makes the agent completely unusable inside a VM, while working fine on the host —
which is a confusing failure mode to debug, since nothing about the credentials, the
config, or the agent differs between the two.

## Root cause

`atob` is a WHATWG API, not an ECMAScript one, so the bare V8 runtime does not provide it
and the bridge polyfills it in
[`packages/build-tools/bridge-src/builtins/process.ts#L1162-L1173`](https://github.com/rivet-dev/agentos/blob/9953769ec67d98a1ab7a0e52677c86444c14d536/packages/build-tools/bridge-src/builtins/process.ts#L1162-L1173)
by delegating straight to the vendored base64-js (`bridge-src/vendor/buffer.ts`, imported
on line 12). base64-js implements RFC 4648 §4, so the polyfill deviates from
[forgiving-base64 decode](https://infra.spec.whatwg.org/#forgiving-base64-decode) in both
directions:

- **Too strict** — `getLens()` (`vendor/buffer.ts#L22-L25`) throws
  `Invalid string. Length must be a multiple of 4` on unpadded input. The spec only fails
  at `length % 4 === 1`. This is the bug I hit.
- **Too lax** — `vendor/buffer.ts#L20-L21` maps `-`/`_` to 62/63, so base64url input is
  accepted where the spec requires rejection.

## Reproduction

Inside any agentOS VM:

```js
atob("eyJhIjoxfQ")    // → Error: Invalid string. Length must be a multiple of 4
atob("eyJhIjoxfQ==")  // → {"a":1}
Both return {"a":1} on Node, Bun, and in browsers. The runtime reports
process.versions.node = 22.0.0, so agents reasonably assume Node-compatible globals.
```

## Validation

- `pnpm --dir packages/build-tools run build:v8-bridge`
- `AGENTOS_BUILTIN_CONFORMANCE_CASE=global_base64 cargo +1.91.1 test -p agentos-native-sidecar --test builtin_conformance __builtin_conformance_case_runner -- --nocapture`
- `pnpm --dir packages/build-tools test`
- `git diff --check`