### PR TITLE
feat(sandbox): keep mount endpoints stable

### DIFF
--- a/packages/agentos-sandbox/src/provider.ts
+++ b/packages/agentos-sandbox/src/provider.ts
@@ -13,7 +13,70 @@ export type SandboxAgentProviderOptions = Omit<
 	"sandbox" | "sandboxId"
 >;
 
-/** Adapt any sandbox-agent backend into a per-VM AgentOS sandbox provider. */
+interface SandboxAgentTransportInternals {
+	baseUrl: string;
+	token?: string;
+	defaultHeaders?: HeadersInit;
+	fetcher?: typeof globalThis.fetch;
+	awaitHealthy?(signal?: AbortSignal): Promise<void>;
+}
+
+function validateTransportBaseUrl(raw: string): string {
+	const normalized = raw.trim().replace(/\/+$/, "");
+	if (!normalized) throw new Error("SandboxAgent baseUrl must not be empty");
+	const url = new URL(normalized);
+	if (!url.hostname || url.search || url.hash) {
+		throw new Error(
+			"SandboxAgent baseUrl must include a host without a query string or fragment",
+		);
+	}
+	const hostname = url.hostname
+		.replace(/^\[/, "")
+		.replace(/\]$/, "")
+		.toLowerCase();
+	const loopback =
+		hostname === "localhost" ||
+		hostname === "::1" ||
+		/^127(?:\.|$)/.test(hostname);
+	if (url.protocol !== "http:" && url.protocol !== "https:") {
+		throw new Error("SandboxAgent baseUrl must use http or https");
+	}
+	if (url.protocol !== "https:" && !loopback) {
+		throw new Error(
+			"SandboxAgent baseUrl must use https unless it targets localhost",
+		);
+	}
+	return normalized;
+}
+
+async function requestThroughSandboxAgent(
+	client: SandboxAgent,
+	path: string,
+	init: RequestInit = {},
+): Promise<Response> {
+	const transport = client as unknown as SandboxAgentTransportInternals;
+	await transport.awaitHealthy?.(init.signal ?? undefined);
+	if (typeof transport.fetcher !== "function") {
+		throw new Error(
+			"SandboxAgent client does not expose the authenticated fetch transport required by agentOS",
+		);
+	}
+	const headers = new Headers(transport.defaultHeaders);
+	new Headers(init.headers).forEach((value, name) => headers.set(name, value));
+	if (transport.token) {
+		headers.set("authorization", `Bearer ${transport.token}`);
+	}
+	return await transport.fetcher(
+		new URL(`${validateTransportBaseUrl(transport.baseUrl)}${path}`),
+		{
+			...init,
+			headers,
+			redirect: "manual",
+		},
+	);
+}
+
+/** Adapt any sandbox-agent backend into a per-VM agentOS sandbox provider. */
 export function sandboxAgentProvider(
 	backend: SandboxAgentBackend,
 	options: SandboxAgentProviderOptions = {},
@@ -25,6 +88,10 @@ export function sandboxAgentProvider(
 				get(target, property) {
 					if (property === "dispose") {
 						return target.destroySandbox.bind(target);
+					}
+					if (property === "request") {
+						return (path: string, init?: RequestInit) =>
+							requestThroughSandboxAgent(target, path, init);
 					}
 					const value = Reflect.get(target, property, target);
 					return typeof value === "function" ? value.bind(target) : value;

--- a/packages/agentos-sandbox/src/provider.ts
+++ b/packages/agentos-sandbox/src/provider.ts
@@ -16,7 +16,7 @@ export type SandboxAgentProviderOptions = Omit<
 interface SandboxAgentTransportInternals {
 	baseUrl: string;
 	token?: string;
-	defaultHeaders?: HeadersInit;
+	defaultHeaders?: RequestInit["headers"];
 	fetcher?: typeof globalThis.fetch;
 	awaitHealthy?(signal?: AbortSignal): Promise<void>;
 }
@@ -62,7 +62,9 @@ async function requestThroughSandboxAgent(
 		);
 	}
 	const headers = new Headers(transport.defaultHeaders);
-	new Headers(init.headers).forEach((value, name) => headers.set(name, value));
+	new Headers(init.headers).forEach((value, name) => {
+		headers.set(name, value);
+	});
 	if (transport.token) {
 		headers.set("authorization", `Bearer ${transport.token}`);
 	}

--- a/packages/agentos-sandbox/tests/provider.test.ts
+++ b/packages/agentos-sandbox/tests/provider.test.ts
@@ -6,8 +6,17 @@ describe("sandboxAgentProvider", () => {
 	test("starts a fresh client and destroys its backend on disposal", async () => {
 		const destroySandbox = vi.fn(async () => {});
 		const runProcess = vi.fn(async () => ({ stdout: "ok", exitCode: 0 }));
+		const awaitHealthy = vi.fn(async () => {});
+		const fetcher = vi.fn(
+			async (_input: RequestInfo | URL, _init?: RequestInit) =>
+				new Response("ok"),
+		);
 		const client = {
 			baseUrl: "https://sandbox.example",
+			token: "current-token",
+			defaultHeaders: { "x-sandbox-provider": "test" },
+			fetcher,
+			awaitHealthy,
 			destroySandbox,
 			runProcess,
 		};
@@ -25,6 +34,19 @@ describe("sandboxAgentProvider", () => {
 			stdout: "ok",
 			exitCode: 0,
 		});
+		await first.request?.("/v1/fs/stat?path=%2F", {
+			headers: { range: "bytes=0-3" },
+		});
+		expect(awaitHealthy).toHaveBeenCalledTimes(1);
+		expect(fetcher).toHaveBeenCalledTimes(1);
+		const [requestUrl, requestInit] = fetcher.mock.calls[0] ?? [];
+		expect(String(requestUrl)).toBe(
+			"https://sandbox.example/v1/fs/stat?path=%2F",
+		);
+		const headers = new Headers(requestInit?.headers);
+		expect(headers.get("authorization")).toBe("Bearer current-token");
+		expect(headers.get("x-sandbox-provider")).toBe("test");
+		expect(headers.get("range")).toBe("bytes=0-3");
 		await first.dispose?.();
 		await second.dispose?.();
 		expect(destroySandbox).toHaveBeenCalledTimes(2);

--- a/packages/agentos-sandbox/tests/vm-integration.test.ts
+++ b/packages/agentos-sandbox/tests/vm-integration.test.ts
@@ -47,7 +47,7 @@ describe("VM integration", () => {
 			software: [common],
 			sandbox: {
 				mountPath: "/sandbox",
-				idleTimeoutMs: 25,
+				idleTimeoutMs: 500,
 				provider: {
 					start: async () => {
 						providerStarts += 1;
@@ -119,9 +119,7 @@ describe("VM integration", () => {
 				new TextEncoder().encode("first"),
 			);
 			expect(
-				new TextDecoder().decode(
-					await vm.readFile("/sandbox/generation.txt"),
-				),
+				new TextDecoder().decode(await vm.readFile("/sandbox/generation.txt")),
 			).toBe("first");
 			expect(providerStarts).toBe(1);
 
@@ -130,15 +128,32 @@ describe("VM integration", () => {
 				{ path: "/generation.txt" },
 				new TextEncoder().encode("second"),
 			);
-			for (let attempt = 0; attempt < 50 && providerDisposals === 0; attempt++) {
+			for (
+				let attempt = 0;
+				attempt < 100 && providerDisposals === 0;
+				attempt++
+			) {
 				await new Promise((resolve) => setTimeout(resolve, 10));
 			}
 			expect(providerDisposals).toBe(1);
-			expect(
-				new TextDecoder().decode(
-					await vm.readFile("/sandbox/generation.txt"),
+			const [secondContent, bindingResult] = await Promise.all([
+				vm.readFile("/sandbox/generation.txt"),
+				vm.process.execFile(
+					"agentos-sandbox",
+					["run-command", "--command", "echo", "--args", "second-generation"],
+					{ output: { capture: "all" } },
 				),
-			).toBe("second");
+			]);
+			expect(new TextDecoder().decode(secondContent)).toBe("second");
+			expect(bindingResult.exitCode).toBe(0);
+			expect(JSON.parse(bindingResult.stdout)).toEqual(
+				expect.objectContaining({
+					ok: true,
+					result: expect.objectContaining({
+						stdout: expect.stringContaining("second-generation"),
+					}),
+				}),
+			);
 			expect(providerStarts).toBe(2);
 		} finally {
 			await replacement.stop();

--- a/packages/agentos-sandbox/tests/vm-integration.test.ts
+++ b/packages/agentos-sandbox/tests/vm-integration.test.ts
@@ -14,6 +14,7 @@ import {
 import { createSandboxBindings } from "../src/index.js";
 
 let sandbox: MockSandboxAgentHandle;
+let providerSandbox: MockSandboxAgentHandle;
 
 const SANDBOX_TEST_PERMISSIONS = {
 	fs: "allow",
@@ -24,7 +25,8 @@ const SANDBOX_TEST_PERMISSIONS = {
 } as const;
 
 beforeAll(async () => {
-	sandbox = await startMockSandboxAgent();
+	sandbox = await startMockSandboxAgent({ token: "first-generation-token" });
+	providerSandbox = sandbox;
 }, 150_000);
 
 afterAll(async () => {
@@ -39,15 +41,17 @@ describe("VM integration", () => {
 	beforeEach(async () => {
 		providerStarts = 0;
 		providerDisposals = 0;
+		providerSandbox = sandbox;
 		vm = await AgentOs.create({
 			permissions: SANDBOX_TEST_PERMISSIONS,
 			software: [common],
 			sandbox: {
 				mountPath: "/sandbox",
+				idleTimeoutMs: 25,
 				provider: {
 					start: async () => {
 						providerStarts += 1;
-						return new Proxy(sandbox.client, {
+						return new Proxy(providerSandbox.client, {
 							get(target, property) {
 								if (property === "dispose") {
 									return () => {
@@ -62,12 +66,12 @@ describe("VM integration", () => {
 				},
 			},
 		});
-		expect(providerStarts).toBe(1);
+		expect(providerStarts).toBe(0);
 	}, 150_000);
 
 	afterEach(async () => {
 		if (vm) await vm.dispose();
-		expect(providerDisposals).toBe(1);
+		expect(providerDisposals).toBe(providerStarts);
 	});
 
 	// -- Filesystem mount tests --
@@ -104,6 +108,42 @@ describe("VM integration", () => {
 		const content = await vm.readFile("/sandbox/nested/deep.txt");
 		expect(new TextDecoder().decode(content)).toBe("deep file");
 	});
+
+	it("keeps the mounted path live when the backing sandbox endpoint changes", async () => {
+		const replacement = await startMockSandboxAgent({
+			token: "second-generation-token",
+		});
+		try {
+			await sandbox.client.writeFsFile(
+				{ path: "/generation.txt" },
+				new TextEncoder().encode("first"),
+			);
+			expect(
+				new TextDecoder().decode(
+					await vm.readFile("/sandbox/generation.txt"),
+				),
+			).toBe("first");
+			expect(providerStarts).toBe(1);
+
+			providerSandbox = replacement;
+			await replacement.client.writeFsFile(
+				{ path: "/generation.txt" },
+				new TextEncoder().encode("second"),
+			);
+			for (let attempt = 0; attempt < 50 && providerDisposals === 0; attempt++) {
+				await new Promise((resolve) => setTimeout(resolve, 10));
+			}
+			expect(providerDisposals).toBe(1);
+			expect(
+				new TextDecoder().decode(
+					await vm.readFile("/sandbox/generation.txt"),
+				),
+			).toBe("second");
+			expect(providerStarts).toBe(2);
+		} finally {
+			await replacement.stop();
+		}
+	}, 150_000);
 
 	// -- Bindings direct execution (host RPC, not via CLI shim) --
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -53,5 +53,6 @@ export {
 	createSandboxFs,
 	getSandboxDisposeHooks,
 	resolveSandboxOptions,
+	SandboxStartupError,
 } from "./sandbox.js";
 export type * from "./types.js";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,7 +1,19 @@
 // @rivet-dev/agentos
 
 export { AgentOs, AgentOsSidecar } from "./agent-os.js";
-export type * from "./language-execution.js";
+export {
+	isPackageDescriptor,
+	OPT_AGENTOS_BIN,
+	OPT_AGENTOS_ROOT,
+	tryReadAgentosPackageManifest,
+} from "./agentos-package.js";
+export type { Binding, BindingExample, Bindings } from "./bindings.js";
+export {
+	binding,
+	bindings,
+	MAX_BINDING_DESCRIPTION_LENGTH,
+	validateBindings,
+} from "./bindings.js";
 export {
 	CronManager,
 	InvalidScheduleError,
@@ -9,18 +21,14 @@ export {
 	TimerScheduleDriver,
 } from "./cron/index.js";
 export { createHostDirBackend, nodeModulesMount } from "./host-dir-mount.js";
-export {
-	binding,
-	MAX_BINDING_DESCRIPTION_LENGTH,
-	bindings,
-	validateBindings,
-} from "./bindings.js";
-export type { Binding, BindingExample, Bindings } from "./bindings.js";
+export type * from "./language-execution.js";
+export { createSnapshotExport } from "./layers.js";
 export {
 	agentOsLimitsSchema,
 	agentOsOptionFieldSchemas,
 	agentOsOptionsSchema,
 	bindingSchema,
+	bindingsSchema,
 	mountConfigSchema,
 	nativeMountConfigSchema,
 	parseAgentOsOptions,
@@ -28,17 +36,8 @@ export {
 	rootFilesystemConfigSchema,
 	sharedSidecarConfigSchema,
 	sidecarConfigSchema,
-	bindingsSchema,
 } from "./options-schema.js";
-export { createSnapshotExport } from "./layers.js";
 export { defineSoftware } from "./packages.js";
-export {
-	isPackageDescriptor,
-	OPT_AGENTOS_BIN,
-	OPT_AGENTOS_ROOT,
-	tryReadAgentosPackageManifest,
-} from "./agentos-package.js";
-export { KernelError } from "./runtime-compat.js";
 export type {
 	ExecOptions,
 	ExecResult,
@@ -48,6 +47,7 @@ export type {
 	VirtualDirEntry,
 	VirtualStat,
 } from "./runtime.js";
+export { KernelError } from "./runtime-compat.js";
 export {
 	createSandboxBindings,
 	createSandboxFs,

--- a/packages/core/src/sandbox-relay.ts
+++ b/packages/core/src/sandbox-relay.ts
@@ -162,7 +162,9 @@ function mergeUpstreamHeaders(
 	const serializable = client as AgentOsSandboxClient &
 		SerializableSandboxClient;
 	const headers = new Headers(serializable.defaultHeaders);
-	requestHeaders.forEach((value, name) => headers.set(name, value));
+	requestHeaders.forEach((value, name) => {
+		headers.set(name, value);
+	});
 	if (serializable.token) {
 		headers.set("authorization", `Bearer ${serializable.token}`);
 	}
@@ -236,7 +238,10 @@ export async function createSandboxRelay(
 	const token = randomBytes(32).toString("base64url");
 	const maxConcurrentRequests =
 		options.maxConcurrentRequests ?? DEFAULT_MAX_RELAY_REQUESTS;
-	if (!Number.isSafeInteger(maxConcurrentRequests) || maxConcurrentRequests <= 0) {
+	if (
+		!Number.isSafeInteger(maxConcurrentRequests) ||
+		maxConcurrentRequests <= 0
+	) {
 		throw new Error("sandbox.maxRelayRequests must be a positive safe integer");
 	}
 
@@ -283,8 +288,7 @@ export async function createSandboxRelay(
 			activeRequests += 1;
 			if (
 				!warnedNearCapacity &&
-				activeRequests * 100 >=
-					maxConcurrentRequests * RELAY_WARNING_PERCENT
+				activeRequests * 100 >= maxConcurrentRequests * RELAY_WARNING_PERCENT
 			) {
 				warnedNearCapacity = true;
 				console.warn(
@@ -308,7 +312,7 @@ export async function createSandboxRelay(
 							signal: abortController.signal,
 							...(hasBody
 								? {
-										body: Readable.toWeb(request) as unknown as BodyInit,
+										body: Readable.toWeb(request) as never,
 										duplex: "half" as const,
 									}
 								: {}),

--- a/packages/core/src/sandbox-relay.ts
+++ b/packages/core/src/sandbox-relay.ts
@@ -1,0 +1,382 @@
+import { randomBytes, timingSafeEqual } from "node:crypto";
+import { once } from "node:events";
+import {
+	createServer,
+	type IncomingHttpHeaders,
+	type Server,
+	type ServerResponse,
+} from "node:http";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import type { ReadableStream as NodeReadableStream } from "node:stream/web";
+import type { AgentOsSandboxClient } from "./sandbox.js";
+
+const DEFAULT_MAX_RELAY_REQUESTS = 64;
+const RELAY_WARNING_PERCENT = 80;
+const HOP_BY_HOP_HEADERS = new Set([
+	"connection",
+	"keep-alive",
+	"proxy-authenticate",
+	"proxy-authorization",
+	"proxy-connection",
+	"te",
+	"trailer",
+	"transfer-encoding",
+	"upgrade",
+]);
+const ALLOWED_RELAY_ROUTES = new Map<string, ReadonlySet<string>>([
+	["/v1/fs/entries", new Set(["GET"])],
+	["/v1/fs/file", new Set(["GET", "PUT"])],
+	["/v1/fs/entry", new Set(["DELETE"])],
+	["/v1/fs/mkdir", new Set(["POST"])],
+	["/v1/fs/move", new Set(["POST"])],
+	["/v1/fs/stat", new Set(["GET"])],
+	["/v1/processes/run", new Set(["POST"])],
+]);
+
+export interface SandboxRelayClientController {
+	withClient<T>(
+		operation: (client: AgentOsSandboxClient) => Promise<T>,
+	): Promise<T>;
+}
+
+export interface SandboxRelayOptions {
+	controller: SandboxRelayClientController;
+	maxConcurrentRequests?: number;
+}
+
+export interface SandboxRelay {
+	baseUrl: string;
+	token: string;
+	dispose(): Promise<void>;
+}
+
+interface SerializableSandboxClient {
+	baseUrl?: string;
+	token?: string;
+	defaultHeaders?: RequestInit["headers"];
+}
+
+type RelayRequestInit = RequestInit & { duplex?: "half" };
+
+function problem(
+	response: ServerResponse,
+	status: number,
+	title: string,
+	detail: string,
+): void {
+	if (response.headersSent) {
+		response.destroy(new Error(detail));
+		return;
+	}
+	const body = Buffer.from(
+		JSON.stringify({
+			type: "about:blank",
+			title,
+			status,
+			detail,
+		}),
+	);
+	response.writeHead(status, {
+		"content-length": String(body.length),
+		"content-type": "application/problem+json",
+	});
+	response.end(body);
+}
+
+function bearerToken(headers: IncomingHttpHeaders): string | undefined {
+	const authorization = headers.authorization;
+	if (!authorization?.startsWith("Bearer ")) return undefined;
+	return authorization.slice("Bearer ".length);
+}
+
+function tokenMatches(actual: string | undefined, expected: string): boolean {
+	if (!actual) return false;
+	const actualBytes = Buffer.from(actual);
+	const expectedBytes = Buffer.from(expected);
+	return (
+		actualBytes.length === expectedBytes.length &&
+		timingSafeEqual(actualBytes, expectedBytes)
+	);
+}
+
+function isAllowedRelayRoute(method: string, pathname: string): boolean {
+	return ALLOWED_RELAY_ROUTES.get(pathname)?.has(method) === true;
+}
+
+function copyRequestHeaders(headers: IncomingHttpHeaders): Headers {
+	const copied = new Headers();
+	for (const [name, value] of Object.entries(headers)) {
+		const lower = name.toLowerCase();
+		if (
+			value === undefined ||
+			lower === "accept-encoding" ||
+			lower === "authorization" ||
+			lower === "host" ||
+			HOP_BY_HOP_HEADERS.has(lower)
+		) {
+			continue;
+		}
+		if (Array.isArray(value)) {
+			for (const item of value) copied.append(name, item);
+		} else {
+			copied.set(name, value);
+		}
+	}
+	copied.set("accept-encoding", "identity");
+	return copied;
+}
+
+function validateUpstreamBaseUrl(raw: string): string {
+	const normalized = raw.trim().replace(/\/+$/, "");
+	if (!normalized) throw new Error("Sandbox client baseUrl must not be empty");
+	const url = new URL(normalized);
+	if (!url.hostname || url.search || url.hash) {
+		throw new Error(
+			"Sandbox client baseUrl must include a host without a query string or fragment",
+		);
+	}
+	if (url.protocol !== "http:" && url.protocol !== "https:") {
+		throw new Error("Sandbox client baseUrl must use http or https");
+	}
+	const hostname = url.hostname
+		.replace(/^\[/, "")
+		.replace(/\]$/, "")
+		.toLowerCase();
+	const loopback =
+		hostname === "localhost" ||
+		hostname === "::1" ||
+		/^127(?:\.|$)/.test(hostname);
+	if (url.protocol !== "https:" && !loopback) {
+		throw new Error(
+			"Sandbox client baseUrl must use https unless it targets localhost",
+		);
+	}
+	return normalized;
+}
+
+function mergeUpstreamHeaders(
+	client: AgentOsSandboxClient,
+	requestHeaders: Headers,
+): Headers {
+	const serializable = client as AgentOsSandboxClient &
+		SerializableSandboxClient;
+	const headers = new Headers(serializable.defaultHeaders);
+	requestHeaders.forEach((value, name) => headers.set(name, value));
+	if (serializable.token) {
+		headers.set("authorization", `Bearer ${serializable.token}`);
+	}
+	return headers;
+}
+
+async function requestUpstream(
+	client: AgentOsSandboxClient,
+	path: string,
+	init: RelayRequestInit,
+): Promise<Response> {
+	const headers = mergeUpstreamHeaders(client, new Headers(init.headers));
+	const upstreamInit: RelayRequestInit = {
+		...init,
+		headers,
+		redirect: "manual",
+	};
+	if (client.request) {
+		return await client.request(path, upstreamInit);
+	}
+
+	const serializable = client as AgentOsSandboxClient &
+		SerializableSandboxClient;
+	const rawBaseUrl = serializable.baseUrl;
+	if (!rawBaseUrl) {
+		throw new Error(
+			"Sandbox client does not expose request() or a serializable baseUrl",
+		);
+	}
+	const baseUrl = validateUpstreamBaseUrl(rawBaseUrl);
+	return await fetch(`${baseUrl}${path}`, upstreamInit);
+}
+
+function copyResponseHeaders(headers: Headers): Record<string, string> {
+	const copied: Record<string, string> = {};
+	headers.forEach((value, name) => {
+		if (!HOP_BY_HOP_HEADERS.has(name.toLowerCase())) copied[name] = value;
+	});
+	return copied;
+}
+
+async function writeUpstreamResponse(
+	upstream: Response,
+	response: ServerResponse,
+): Promise<void> {
+	response.writeHead(upstream.status, copyResponseHeaders(upstream.headers));
+	if (!upstream.body) {
+		response.end();
+		return;
+	}
+	const body = Readable.fromWeb(
+		upstream.body as unknown as NodeReadableStream<Uint8Array>,
+	);
+	await pipeline(body, response);
+}
+
+function closeServer(server: Server): Promise<void> {
+	return new Promise((resolve, reject) => {
+		server.close((error) => {
+			if (error) reject(error);
+			else resolve();
+		});
+		server.closeIdleConnections();
+		server.closeAllConnections();
+	});
+}
+
+export async function createSandboxRelay(
+	options: SandboxRelayOptions,
+): Promise<SandboxRelay> {
+	const token = randomBytes(32).toString("base64url");
+	const maxConcurrentRequests =
+		options.maxConcurrentRequests ?? DEFAULT_MAX_RELAY_REQUESTS;
+	if (!Number.isSafeInteger(maxConcurrentRequests) || maxConcurrentRequests <= 0) {
+		throw new Error("sandbox.maxRelayRequests must be a positive safe integer");
+	}
+
+	let activeRequests = 0;
+	let warnedNearCapacity = false;
+	let disposed = false;
+	const server = createServer((request, response) => {
+		void (async () => {
+			if (disposed) {
+				problem(
+					response,
+					503,
+					"Sandbox relay unavailable",
+					"agentOS VM sandbox relay is shutting down",
+				);
+				return;
+			}
+			if (!tokenMatches(bearerToken(request.headers), token)) {
+				problem(response, 401, "Unauthorized", "Invalid sandbox relay token");
+				return;
+			}
+
+			const url = new URL(request.url ?? "/", "http://127.0.0.1");
+			const method = request.method ?? "GET";
+			if (!isAllowedRelayRoute(method, url.pathname)) {
+				problem(
+					response,
+					404,
+					"Not Found",
+					`Sandbox relay does not expose ${method} ${url.pathname}`,
+				);
+				return;
+			}
+			if (activeRequests >= maxConcurrentRequests) {
+				problem(
+					response,
+					429,
+					"Sandbox relay capacity exceeded",
+					`Sandbox relay reached sandbox.maxRelayRequests=${maxConcurrentRequests}; raise sandbox.maxRelayRequests to allow more concurrent requests`,
+				);
+				return;
+			}
+
+			activeRequests += 1;
+			if (
+				!warnedNearCapacity &&
+				activeRequests * 100 >=
+					maxConcurrentRequests * RELAY_WARNING_PERCENT
+			) {
+				warnedNearCapacity = true;
+				console.warn(
+					`agentOS sandbox relay near sandbox.maxRelayRequests: ${activeRequests}/${maxConcurrentRequests}`,
+				);
+			}
+			try {
+				await options.controller.withClient(async (client) => {
+					const abortController = new AbortController();
+					const abort = () => {
+						if (!response.writableEnded) abortController.abort();
+					};
+					request.once("aborted", abort);
+					response.once("close", abort);
+					try {
+						const hasBody = method !== "GET" && method !== "HEAD";
+						const init: RelayRequestInit = {
+							method,
+							headers: copyRequestHeaders(request.headers),
+							redirect: "manual",
+							signal: abortController.signal,
+							...(hasBody
+								? {
+										body: Readable.toWeb(request) as unknown as BodyInit,
+										duplex: "half" as const,
+									}
+								: {}),
+						};
+						const upstream = await requestUpstream(
+							client,
+							`${url.pathname}${url.search}`,
+							init,
+						);
+						await writeUpstreamResponse(upstream, response);
+					} finally {
+						request.off("aborted", abort);
+						response.off("close", abort);
+					}
+				});
+			} catch (error) {
+				const detail = error instanceof Error ? error.message : String(error);
+				problem(response, 503, "Sandbox unavailable", detail);
+			} finally {
+				activeRequests -= 1;
+				if (
+					activeRequests * 100 <
+					maxConcurrentRequests * RELAY_WARNING_PERCENT
+				) {
+					warnedNearCapacity = false;
+				}
+			}
+		})().catch((error) => {
+			console.error("agentOS sandbox relay request failed", error);
+			problem(
+				response,
+				500,
+				"Sandbox relay failure",
+				error instanceof Error ? error.message : String(error),
+			);
+		});
+	});
+	server.maxConnections = Math.min(
+		Number.MAX_SAFE_INTEGER,
+		maxConcurrentRequests + 1,
+	);
+	server.listen(0, "127.0.0.1");
+	try {
+		await Promise.race([
+			once(server, "listening"),
+			once(server, "error").then(([error]) => Promise.reject(error)),
+		]);
+	} catch (error) {
+		await closeServer(server).catch((closeError) => {
+			console.error("agentOS sandbox relay cleanup failed", closeError);
+		});
+		throw error;
+	}
+	server.unref();
+
+	const address = server.address();
+	if (!address || typeof address === "string") {
+		await closeServer(server);
+		throw new Error("Sandbox relay failed to bind to a TCP port");
+	}
+
+	return {
+		baseUrl: `http://127.0.0.1:${address.port}`,
+		token,
+		async dispose() {
+			if (disposed) return;
+			disposed = true;
+			await closeServer(server);
+		},
+	};
+}

--- a/packages/core/src/sandbox.ts
+++ b/packages/core/src/sandbox.ts
@@ -5,6 +5,13 @@ import type {
 	NativeMountPluginDescriptor,
 } from "./agent-os.js";
 import type { Binding, Bindings } from "./bindings.js";
+import {
+	createSandboxRelay,
+	type SandboxRelayClientController,
+} from "./sandbox-relay.js";
+
+const DEFAULT_SANDBOX_IDLE_TIMEOUT_MS = 5 * 60_000;
+const DEFAULT_SANDBOX_STARTUP_TIMEOUT_MS = 20_000;
 
 export interface AgentOsSandboxProcessResult {
 	stdout?: string;
@@ -34,6 +41,12 @@ export interface AgentOsSandboxProcessLogs {
 
 export interface AgentOsSandboxClient {
 	dispose?(): Promise<void> | void;
+	/**
+	 * Optional authenticated raw transport used by the native filesystem relay.
+	 * The path always starts with `/v1/` and includes its query string. Return the
+	 * upstream Response unchanged, including non-success HTTP statuses.
+	 */
+	request?(path: string, init?: RequestInit): Promise<Response>;
 	runProcess(options: {
 		command: string;
 		args?: string[];
@@ -73,6 +86,15 @@ export interface AgentOsSandboxCommonOptions {
 	timeoutMs?: number;
 	/** Maximum file size allowed for buffered pread/truncate fallbacks. */
 	maxFullReadBytes?: number;
+	/**
+	 * Shut down an inactive provider sandbox after this duration. The next
+	 * operation starts a new sandbox. Set to 0 to disable. Defaults to 5 minutes.
+	 */
+	idleTimeoutMs?: number;
+	/** Maximum time to wait for a provider start. Set to 0 to disable. Defaults to 20 seconds. */
+	startupTimeoutMs?: number;
+	/** Maximum concurrent native filesystem relay requests. Defaults to 64. */
+	maxRelayRequests?: number;
 	/** Marks the VM mount read-only. Defaults to false. */
 	readOnly?: boolean;
 }
@@ -113,6 +135,245 @@ export type AgentOsSandboxExpandedOptions = {
 type ResolvedSandboxOptions = AgentOsSandboxCommonOptions & {
 	client: AgentOsSandboxClient;
 };
+
+export class SandboxStartupError extends Error {
+	constructor(message: string, options?: ErrorOptions) {
+		super(message, options);
+		this.name = "SandboxStartupError";
+	}
+}
+
+class SandboxClientController implements SandboxRelayClientController {
+	readonly #provider?: AgentOsSandboxProvider;
+	readonly #startupTimeoutMs: number;
+	readonly #idleTimeoutMs: number;
+	readonly #disposeClient?: SandboxDisposeHook;
+	#current?: AgentOsSandboxClient;
+	#startPromise?: Promise<AgentOsSandboxClient>;
+	#stopPromise?: Promise<void>;
+	#idleTimer?: NodeJS.Timeout;
+	#activeOperations = 0;
+	#disposed = false;
+
+	constructor(options: {
+		provider?: AgentOsSandboxProvider;
+		client?: AgentOsSandboxClient;
+		disposeClient?: SandboxDisposeHook;
+		startupTimeoutMs?: number;
+		idleTimeoutMs?: number;
+	}) {
+		this.#provider = options.provider;
+		this.#current = options.client;
+		this.#disposeClient = options.disposeClient;
+		this.#startupTimeoutMs =
+			options.startupTimeoutMs ?? DEFAULT_SANDBOX_STARTUP_TIMEOUT_MS;
+		this.#idleTimeoutMs =
+			options.idleTimeoutMs ?? DEFAULT_SANDBOX_IDLE_TIMEOUT_MS;
+		for (const [name, value] of [
+			["sandbox.startupTimeoutMs", this.#startupTimeoutMs],
+			["sandbox.idleTimeoutMs", this.#idleTimeoutMs],
+		] as const) {
+			if (!Number.isSafeInteger(value) || value < 0) {
+				throw new Error(`${name} must be a non-negative safe integer`);
+			}
+		}
+	}
+
+	async withClient<T>(
+		operation: (client: AgentOsSandboxClient) => Promise<T>,
+	): Promise<T> {
+		if (this.#disposed) {
+			throw new Error("agentOS VM sandbox has been disposed");
+		}
+		this.#clearIdleTimer();
+		this.#activeOperations += 1;
+		try {
+			return await operation(await this.#getClient());
+		} finally {
+			this.#activeOperations -= 1;
+			this.#scheduleIdleStop();
+		}
+	}
+
+	async #getClient(): Promise<AgentOsSandboxClient> {
+		if (this.#disposed) {
+			throw new Error("agentOS VM sandbox has been disposed");
+		}
+		if (this.#current) return this.#current;
+		if (!this.#provider) {
+			throw new Error("Sandbox client is not available");
+		}
+		if (this.#stopPromise) await this.#stopPromise;
+		if (this.#current) return this.#current;
+		if (this.#startPromise) return await this.#startPromise;
+
+		const startPromise = this.#startProvider();
+		this.#startPromise = startPromise;
+		try {
+			return await startPromise;
+		} finally {
+			if (this.#startPromise === startPromise) this.#startPromise = undefined;
+		}
+	}
+
+	async #startProvider(): Promise<AgentOsSandboxClient> {
+		const provider = this.#provider;
+		if (!provider) throw new Error("Sandbox provider is not configured");
+
+		let abandoned = false;
+		let timeout: NodeJS.Timeout | undefined;
+		let providerResult: Promise<AgentOsSandboxClient>;
+		try {
+			providerResult = Promise.resolve(provider.start());
+		} catch (error) {
+			providerResult = Promise.reject(error);
+		}
+		const providerStart = providerResult.then(async (client) => {
+			if (!client || typeof client !== "object") {
+				throw new Error("sandbox.provider.start() did not return a client");
+			}
+			if (!abandoned && !this.#disposed) return client;
+			try {
+				await client.dispose?.();
+			} catch (error) {
+				console.error("agentOS late sandbox startup cleanup failed", error);
+			}
+			throw new SandboxStartupError(
+				"Sandbox provider completed after its startup was cancelled",
+			);
+		});
+		const timeoutPromise = new Promise<never>((_, reject) => {
+			if (this.#startupTimeoutMs === 0) return;
+			timeout = setTimeout(() => {
+				abandoned = true;
+				reject(
+					new SandboxStartupError(
+						`Sandbox provider startup exceeded sandbox.startupTimeoutMs=${this.#startupTimeoutMs}; raise sandbox.startupTimeoutMs to allow a longer startup`,
+					),
+				);
+			}, this.#startupTimeoutMs);
+		});
+		try {
+			const client = await Promise.race([providerStart, timeoutPromise]);
+			if (this.#disposed) {
+				abandoned = true;
+				await client.dispose?.();
+				throw new SandboxStartupError(
+					"Sandbox provider completed after the agentOS VM was disposed",
+				);
+			}
+			this.#current = client;
+			return client;
+		} catch (error) {
+			abandoned = true;
+			if (error instanceof SandboxStartupError) throw error;
+			throw new SandboxStartupError(
+				`Sandbox provider startup failed: ${error instanceof Error ? error.message : String(error)}`,
+				{ cause: error },
+			);
+		} finally {
+			if (timeout) clearTimeout(timeout);
+		}
+	}
+
+	#clearIdleTimer(): void {
+		if (!this.#idleTimer) return;
+		clearTimeout(this.#idleTimer);
+		this.#idleTimer = undefined;
+	}
+
+	#scheduleIdleStop(): void {
+		this.#clearIdleTimer();
+		if (
+			!this.#provider ||
+			this.#disposed ||
+			this.#idleTimeoutMs === 0 ||
+			this.#activeOperations !== 0 ||
+			!this.#current
+		) {
+			return;
+		}
+		this.#idleTimer = setTimeout(() => {
+			this.#idleTimer = undefined;
+			void this.#stopIdleClient().catch((error) => {
+				console.error("agentOS idle sandbox shutdown failed", error);
+			});
+		}, this.#idleTimeoutMs);
+		this.#idleTimer.unref();
+	}
+
+	async #stopIdleClient(): Promise<void> {
+		if (
+			this.#disposed ||
+			this.#activeOperations !== 0 ||
+			!this.#current ||
+			this.#stopPromise
+		) {
+			return;
+		}
+		const client = this.#current;
+		this.#current = undefined;
+		const stopPromise = Promise.resolve(client.dispose?.()).then(() => undefined);
+		this.#stopPromise = stopPromise;
+		try {
+			await stopPromise;
+		} finally {
+			if (this.#stopPromise === stopPromise) this.#stopPromise = undefined;
+		}
+	}
+
+	async dispose(): Promise<void> {
+		if (this.#disposed) return;
+		this.#disposed = true;
+		this.#clearIdleTimer();
+		const errors: unknown[] = [];
+		try {
+			await this.#startPromise;
+		} catch (error) {
+			errors.push(error);
+		}
+		try {
+			await this.#stopPromise;
+		} catch (error) {
+			errors.push(error);
+		}
+		const client = this.#current;
+		this.#current = undefined;
+		if (client) {
+			try {
+				if (this.#provider) await client.dispose?.();
+				else await this.#disposeClient?.();
+			} catch (error) {
+				errors.push(error);
+			}
+		}
+		if (errors.length === 1) throw errors[0];
+		if (errors.length > 1) {
+			throw new AggregateError(errors, "agentOS sandbox disposal failed");
+		}
+	}
+}
+
+function createControllerClient(
+	controller: SandboxClientController,
+): AgentOsSandboxClient {
+	return {
+		runProcess: (options) =>
+			controller.withClient((client) => client.runProcess(options)),
+		createProcess: (options) =>
+			controller.withClient((client) => client.createProcess(options)),
+		listProcesses: () =>
+			controller.withClient((client) => client.listProcesses()),
+		stopProcess: (id) =>
+			controller.withClient((client) => client.stopProcess(id)),
+		killProcess: (id) =>
+			controller.withClient((client) => client.killProcess(id)),
+		getProcessLogs: (id, options) =>
+			controller.withClient((client) => client.getProcessLogs(id, options)),
+		sendProcessInput: (id, input) =>
+			controller.withClient((client) => client.sendProcessInput(id, input)),
+	};
+}
 
 export type SandboxMountPluginConfig = MountConfigJsonObject & {
 	baseUrl: string;
@@ -367,36 +628,40 @@ function assertNoLegacySandboxOptions(input: AgentOsSandboxInput): void {
 	}
 }
 
-async function normalizeSandboxInput(input: AgentOsSandboxInput): Promise<{
-	options: ResolvedSandboxOptions;
-	dispose?: SandboxDisposeHook;
-}> {
+function createSandboxController(
+	input: AgentOsSandboxInput,
+): SandboxClientController {
 	assertNoLegacySandboxOptions(input);
 	if (isProviderOptions(input)) {
 		if (typeof input.provider?.start !== "function") {
 			throw new Error("sandbox.provider must expose a start() function.");
 		}
-		const client = await input.provider.start();
-		return {
-			options: { ...input, client },
-			dispose: () => client.dispose?.(),
-		};
+		return new SandboxClientController({
+			provider: input.provider,
+			idleTimeoutMs: input.idleTimeoutMs,
+			startupTimeoutMs: input.startupTimeoutMs,
+		});
 	}
 	if (!isClientOptions(input)) {
 		throw new Error(
 			"sandbox must be configured with either { provider } or { client }.",
 		);
 	}
-	const dispose =
+	if (!input.client || typeof input.client !== "object") {
+		throw new Error("sandbox.client must be an object.");
+	}
+	const disposeClient =
 		typeof input.dispose === "function"
 			? input.dispose
 			: input.dispose === true
 				? () => input.client.dispose?.()
 				: undefined;
-	return {
-		options: input,
-		dispose,
-	};
+	return new SandboxClientController({
+		client: input.client,
+		disposeClient,
+		idleTimeoutMs: input.idleTimeoutMs ?? 0,
+		startupTimeoutMs: input.startupTimeoutMs,
+	});
 }
 
 function attachSandboxDisposeHooks<T extends object>(
@@ -438,25 +703,44 @@ export async function resolveSandboxOptions<
 		return rest;
 	}
 
-	const normalizedSandbox = await normalizeSandboxInput(sandbox);
+	const controller = createSandboxController(sandbox);
+	let relay: Awaited<ReturnType<typeof createSandboxRelay>> | undefined;
 	try {
-		const sandboxOptions = normalizedSandbox.options;
+		relay = await createSandboxRelay({
+			controller,
+			maxConcurrentRequests: sandbox.maxRelayRequests,
+		});
 		const expanded = rest as Omit<T, "sandbox"> & {
 			mounts?: MountConfig[];
 			bindings?: Bindings[];
 		};
-		const mountPath = sandboxOptions.mountPath ?? "/mnt/sandbox";
+		const mountPath = sandbox.mountPath ?? "/mnt/sandbox";
+		const plugin: NativeMountPluginDescriptor<SandboxMountPluginConfig> = {
+			id: "sandbox_agent",
+			config: {
+				baseUrl: relay.baseUrl,
+				token: relay.token,
+				...(sandbox.sandboxRoot ? { basePath: sandbox.sandboxRoot } : {}),
+				...(sandbox.timeoutMs != null ? { timeoutMs: sandbox.timeoutMs } : {}),
+				...(sandbox.maxFullReadBytes != null
+					? { maxFullReadBytes: sandbox.maxFullReadBytes }
+					: {}),
+			},
+		};
 		const mounts = [
 			...(expanded.mounts ?? []),
 			{
 				path: mountPath,
-				plugin: createSandboxFs(sandboxOptions),
-				readOnly: sandboxOptions.readOnly,
+				plugin,
+				readOnly: sandbox.readOnly,
 			},
 		];
 		const bindings = [
 			...(expanded.bindings ?? []),
-			createSandboxBindings(sandboxOptions),
+			createSandboxBindings({
+				...sandbox,
+				client: createControllerClient(controller),
+			}),
 		];
 
 		return attachSandboxDisposeHooks(
@@ -465,15 +749,36 @@ export async function resolveSandboxOptions<
 				mounts,
 				bindings,
 			},
-			normalizedSandbox.dispose ? [normalizedSandbox.dispose] : [],
+			[
+				async () => {
+					const results = await Promise.allSettled([
+						relay?.dispose(),
+						controller.dispose(),
+					]);
+					const errors = results.flatMap((result) =>
+						result.status === "rejected" ? [result.reason] : [],
+					);
+					if (errors.length === 1) throw errors[0];
+					if (errors.length > 1) {
+						throw new AggregateError(
+							errors,
+							"agentOS sandbox relay cleanup failed",
+						);
+					}
+				},
+			],
 		);
 	} catch (error) {
-		if (!normalizedSandbox.dispose) throw error;
-		try {
-			await normalizedSandbox.dispose();
-		} catch (disposeError) {
+		const cleanupResults = await Promise.allSettled([
+			relay?.dispose(),
+			controller.dispose(),
+		]);
+		const cleanupErrors = cleanupResults.flatMap((result) =>
+			result.status === "rejected" ? [result.reason] : [],
+		);
+		if (cleanupErrors.length > 0) {
 			throw new AggregateError(
-				[error, disposeError],
+				[error, ...cleanupErrors],
 				"Sandbox configuration and cleanup failed",
 			);
 		}

--- a/packages/core/src/sandbox.ts
+++ b/packages/core/src/sandbox.ts
@@ -203,9 +203,9 @@ class SandboxClientController implements SandboxRelayClientController {
 		if (!this.#provider) {
 			throw new Error("Sandbox client is not available");
 		}
-		if (this.#stopPromise) await this.#stopPromise;
+		if (this.#stopPromise !== undefined) await this.#stopPromise;
 		if (this.#current) return this.#current;
-		if (this.#startPromise) return await this.#startPromise;
+		if (this.#startPromise !== undefined) return await this.#startPromise;
 
 		const startPromise = this.#startProvider();
 		this.#startPromise = startPromise;
@@ -307,13 +307,15 @@ class SandboxClientController implements SandboxRelayClientController {
 			this.#disposed ||
 			this.#activeOperations !== 0 ||
 			!this.#current ||
-			this.#stopPromise
+			this.#stopPromise !== undefined
 		) {
 			return;
 		}
 		const client = this.#current;
 		this.#current = undefined;
-		const stopPromise = Promise.resolve(client.dispose?.()).then(() => undefined);
+		const stopPromise = Promise.resolve(client.dispose?.()).then(
+			() => undefined,
+		);
 		this.#stopPromise = stopPromise;
 		try {
 			await stopPromise;
@@ -416,9 +418,11 @@ function normalizeHeaders(
 	);
 }
 
-function getSerializableClientConfig(
-	client: AgentOsSandboxClient,
-): Pick<SandboxMountPluginConfig, "baseUrl" | "token" | "headers"> {
+function getSerializableClientConfig(client: AgentOsSandboxClient): {
+	baseUrl: string;
+	token?: string;
+	headers?: Record<string, string>;
+} {
 	const serializable = client as unknown as SerializableSandboxClient;
 	const baseUrl = serializable.baseUrl?.trim().replace(/\/+$/, "");
 	if (!baseUrl) {

--- a/packages/core/src/test/sandbox-agent.ts
+++ b/packages/core/src/test/sandbox-agent.ts
@@ -35,6 +35,10 @@ interface ManagedProcess {
 	tty: boolean;
 }
 
+export interface MockSandboxAgentOptions {
+	token?: string;
+}
+
 export interface MockSandboxAgentHandle {
 	baseUrl: string;
 	client: SandboxAgent;
@@ -231,12 +235,21 @@ async function runCommand(request: {
 	});
 }
 
-export async function startMockSandboxAgent(): Promise<MockSandboxAgentHandle> {
+export async function startMockSandboxAgent(
+	options: MockSandboxAgentOptions = {},
+): Promise<MockSandboxAgentHandle> {
 	const rootDir = await mkdtemp(resolve(tmpdir(), "agentos-sandbox-agent-"));
 	const processes = new Map<string, ManagedProcess>();
 
 	const server = createServer(async (request, response) => {
 		try {
+			if (
+				options.token &&
+				request.headers.authorization !== `Bearer ${options.token}`
+			) {
+				problem(response, 401, "Invalid sandbox token");
+				return;
+			}
 			const url = new URL(request.url ?? "/", "http://127.0.0.1");
 			const method = request.method ?? "GET";
 
@@ -503,6 +516,7 @@ export async function startMockSandboxAgent(): Promise<MockSandboxAgentHandle> {
 	const { SandboxAgent } = await import("sandbox-agent");
 	const client = await SandboxAgent.connect({
 		baseUrl,
+		...(options.token ? { token: options.token } : {}),
 		waitForHealth: { timeoutMs: 5_000 },
 	});
 

--- a/packages/core/src/test/sandbox-agent.ts
+++ b/packages/core/src/test/sandbox-agent.ts
@@ -1,10 +1,23 @@
-import { once } from "node:events";
-import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
-import { mkdtemp, mkdir, readFile, readdir, rename, rm, stat, writeFile } from "node:fs/promises";
-import { dirname, relative, resolve } from "node:path";
-import { tmpdir } from "node:os";
+import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { once } from "node:events";
+import {
+	mkdir,
+	mkdtemp,
+	readdir,
+	readFile,
+	rename,
+	rm,
+	stat,
+	writeFile,
+} from "node:fs/promises";
+import {
+	createServer,
+	type IncomingMessage,
+	type ServerResponse,
+} from "node:http";
+import { tmpdir } from "node:os";
+import { dirname, relative, resolve } from "node:path";
 import type { SandboxAgent } from "sandbox-agent";
 
 type ProcessState = "running" | "exited";
@@ -56,7 +69,11 @@ function json(response: ServerResponse, status: number, value: unknown): void {
 	response.end(body);
 }
 
-function problem(response: ServerResponse, status: number, detail: string): void {
+function problem(
+	response: ServerResponse,
+	status: number,
+	detail: string,
+): void {
 	json(response, status, {
 		type: "about:blank",
 		title: status === 404 ? "Not Found" : "Bad Request",
@@ -75,7 +92,9 @@ async function readBody(request: IncomingMessage): Promise<Buffer> {
 
 function decodePath(rootDir: string, rawPath: string | null): string {
 	const candidate = rawPath && rawPath.length > 0 ? rawPath : rootDir;
-	const direct = resolve(candidate.startsWith("/") ? candidate : resolve(rootDir, candidate));
+	const direct = resolve(
+		candidate.startsWith("/") ? candidate : resolve(rootDir, candidate),
+	);
 	const directRel = relative(rootDir, direct);
 	if (!(directRel.startsWith("..") || directRel === "..")) {
 		return direct;
@@ -118,7 +137,11 @@ function processInfo(proc: ManagedProcess) {
 	};
 }
 
-function appendLog(proc: ManagedProcess, stream: ProcessStream, chunk: Buffer): void {
+function appendLog(
+	proc: ManagedProcess,
+	stream: ProcessStream,
+	chunk: Buffer,
+): void {
 	proc.sequence += 1;
 	proc.logs.push({
 		data: chunk.toString("base64"),
@@ -129,7 +152,10 @@ function appendLog(proc: ManagedProcess, stream: ProcessStream, chunk: Buffer): 
 	});
 }
 
-async function waitForProcessExit(proc: ManagedProcess, timeoutMs = 2_000): Promise<void> {
+async function waitForProcessExit(
+	proc: ManagedProcess,
+	timeoutMs = 2_000,
+): Promise<void> {
 	if (proc.status === "exited") {
 		return;
 	}
@@ -166,11 +192,14 @@ async function runCommand(request: {
 		let timedOut = false;
 		const child = spawn(
 			request.command,
-			request.args?.map((value) => mapProcessPath(request.rootDir, value)) ?? [],
+			request.args?.map((value) => mapProcessPath(request.rootDir, value)) ??
+				[],
 			{
-			cwd: request.cwd ? mapProcessPath(request.rootDir, request.cwd) : undefined,
-			env: request.env ? { ...process.env, ...request.env } : process.env,
-			stdio: ["ignore", "pipe", "pipe"],
+				cwd: request.cwd
+					? mapProcessPath(request.rootDir, request.cwd)
+					: undefined,
+				env: request.env ? { ...process.env, ...request.env } : process.env,
+				stdio: ["ignore", "pipe", "pipe"],
 			},
 		);
 
@@ -350,7 +379,9 @@ export async function startMockSandboxAgent(
 			}
 
 			if (method === "POST" && url.pathname === "/v1/processes/run") {
-				const requestBody = JSON.parse((await readBody(request)).toString("utf8")) as {
+				const requestBody = JSON.parse(
+					(await readBody(request)).toString("utf8"),
+				) as {
 					args?: string[];
 					command: string;
 					cwd?: string | null;
@@ -370,7 +401,9 @@ export async function startMockSandboxAgent(
 			}
 
 			if (method === "POST" && url.pathname === "/v1/processes") {
-				const requestBody = JSON.parse((await readBody(request)).toString("utf8")) as {
+				const requestBody = JSON.parse(
+					(await readBody(request)).toString("utf8"),
+				) as {
 					args?: string[];
 					command: string;
 					cwd?: string | null;
@@ -380,7 +413,8 @@ export async function startMockSandboxAgent(
 				};
 				const child = spawn(
 					requestBody.command,
-					requestBody.args?.map((value) => mapProcessPath(rootDir, value)) ?? [],
+					requestBody.args?.map((value) => mapProcessPath(rootDir, value)) ??
+						[],
 					{
 						cwd: requestBody.cwd
 							? mapProcessPath(rootDir, requestBody.cwd)
@@ -408,8 +442,12 @@ export async function startMockSandboxAgent(
 					tty: requestBody.tty === true,
 				};
 				processes.set(proc.id, proc);
-				child.stdout.on("data", (chunk: Buffer) => appendLog(proc, "stdout", chunk));
-				child.stderr.on("data", (chunk: Buffer) => appendLog(proc, "stderr", chunk));
+				child.stdout.on("data", (chunk: Buffer) =>
+					appendLog(proc, "stdout", chunk),
+				);
+				child.stderr.on("data", (chunk: Buffer) =>
+					appendLog(proc, "stderr", chunk),
+				);
 				child.on("close", (code) => {
 					proc.status = "exited";
 					proc.exitCode = code;
@@ -432,7 +470,9 @@ export async function startMockSandboxAgent(
 				return;
 			}
 
-			const processMatch = url.pathname.match(/^\/v1\/processes\/([^/]+)(?:\/(stop|kill|logs|input))?$/);
+			const processMatch = url.pathname.match(
+				/^\/v1\/processes\/([^/]+)(?:\/(stop|kill|logs|input))?$/,
+			);
 			if (processMatch) {
 				const [, rawId, action] = processMatch;
 				const proc = processes.get(decodeURIComponent(rawId));
@@ -480,7 +520,9 @@ export async function startMockSandboxAgent(
 				}
 
 				if (method === "POST" && action === "input") {
-					const body = JSON.parse((await readBody(request)).toString("utf8")) as {
+					const body = JSON.parse(
+						(await readBody(request)).toString("utf8"),
+					) as {
 						data: string;
 						encoding?: string;
 					};
@@ -494,7 +536,11 @@ export async function startMockSandboxAgent(
 				}
 			}
 
-			problem(response, 404, `Unhandled mock sandbox-agent route: ${method} ${url.pathname}`);
+			problem(
+				response,
+				404,
+				`Unhandled mock sandbox-agent route: ${method} ${url.pathname}`,
+			);
 		} catch (error) {
 			problem(
 				response,

--- a/packages/core/tests/options-schema.test.ts
+++ b/packages/core/tests/options-schema.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "vitest";
-import { AgentOs, agentOsOptionsSchema } from "../src/index.js";
+import {
+	AgentOs,
+	agentOsOptionsSchema,
+	SandboxStartupError,
+} from "../src/index.js";
 import {
 	getSandboxDisposeHooks,
 	resolveSandboxOptions,
@@ -112,10 +116,12 @@ describe("AgentOsOptions validation", () => {
 			).toBe(false);
 		}
 	});
-	test("provider sandbox starts a client and owns disposal", async () => {
+	test("provider sandbox starts lazily and owns disposal", async () => {
+		let started = 0;
 		let disposed = false;
 		const client = {
 			baseUrl: "http://127.0.0.1:1234",
+			listProcesses: async () => ({ processes: [] }),
 			dispose: () => {
 				disposed = true;
 			},
@@ -124,22 +130,34 @@ describe("AgentOsOptions validation", () => {
 		const options = await resolveSandboxOptions({
 			sandbox: {
 				provider: {
-					start: async () => client,
+					start: async () => {
+						started += 1;
+						return client;
+					},
 				},
 			},
 		} as never);
 		expect(options).not.toHaveProperty("sandbox");
 		expect(options.mounts?.[0]?.path).toBe("/mnt/sandbox");
 		expect(options.bindings?.[0]?.name).toBe("sandbox");
+		expect(started).toBe(0);
 
+		await options.bindings?.[0]?.bindings["list-processes"].execute({});
+		expect(started).toBe(1);
 		for (const hook of getSandboxDisposeHooks(options)) {
 			await hook();
 		}
 		expect(disposed).toBe(true);
 	});
 
-	test("advanced sandbox client leaves disposal manual by default", async () => {
-		const client = { baseUrl: "http://127.0.0.1:1234" } as never;
+	test("advanced sandbox client leaves client disposal manual by default", async () => {
+		let disposed = false;
+		const client = {
+			baseUrl: "http://127.0.0.1:1234",
+			dispose: () => {
+				disposed = true;
+			},
+		} as never;
 		const options = await resolveSandboxOptions({
 			sandbox: {
 				client,
@@ -147,25 +165,170 @@ describe("AgentOsOptions validation", () => {
 			},
 		} as never);
 		expect(options.mounts?.[0]?.path).toBe("/work");
-		expect(getSandboxDisposeHooks(options)).toHaveLength(0);
+		const mount = options.mounts?.[0];
+		if (!mount || !("plugin" in mount)) {
+			throw new Error("sandbox mount config is missing");
+		}
+		expect(mount.plugin.config.baseUrl).not.toBe("http://127.0.0.1:1234");
+		expect(mount.plugin.config.token).toEqual(expect.any(String));
+		expect(getSandboxDisposeHooks(options)).toHaveLength(1);
+		for (const hook of getSandboxDisposeHooks(options)) await hook();
+		expect(disposed).toBe(false);
 	});
 
-	test("disposes a provider client when sandbox expansion fails", async () => {
+	test("advanced sandbox client can transfer disposal ownership", async () => {
 		let disposed = 0;
-		await expect(
-			resolveSandboxOptions({
-				sandbox: {
-					provider: {
-						start: async () => ({
-							dispose: () => {
-								disposed += 1;
-							},
-						}),
+		const options = await resolveSandboxOptions({
+			sandbox: {
+				client: {
+					baseUrl: "http://127.0.0.1:1234",
+					dispose: async () => {
+						disposed += 1;
+					},
+				} as never,
+				dispose: true,
+			},
+		} as never);
+		for (const hook of getSandboxDisposeHooks(options)) await hook();
+		expect(disposed).toBe(1);
+	});
+
+	test("shares one provider startup across mount and binding calls", async () => {
+		let started = 0;
+		let releaseStart!: () => void;
+		const startGate = new Promise<void>((resolve) => {
+			releaseStart = resolve;
+		});
+		const options = await resolveSandboxOptions({
+			sandbox: {
+				provider: {
+					start: async () => {
+						started += 1;
+						await startGate;
+						return {
+							request: async () =>
+								new Response(
+									JSON.stringify({
+										path: "/",
+										entryType: "directory",
+										size: 0,
+									}),
+									{ headers: { "content-type": "application/json" } },
+								),
+							listProcesses: async () => ({ processes: [] }),
+							dispose: async () => {},
+						} as never;
 					},
 				},
-			} as never),
-		).rejects.toThrow(/serializable baseUrl/);
+			},
+		} as never);
+		const execute = options.bindings?.[0]?.bindings["list-processes"].execute;
+		if (!execute) throw new Error("sandbox list-processes binding is missing");
+		const mount = options.mounts?.[0];
+		if (!mount || !("plugin" in mount)) {
+			throw new Error("sandbox mount config is missing");
+		}
+		const mountConfig = mount.plugin.config;
+		const bindingCall = execute({});
+		const mountCall = fetch(
+			`${String(mountConfig.baseUrl)}/v1/fs/stat?path=%2F`,
+			{
+				headers: {
+					authorization: `Bearer ${String(mountConfig.token)}`,
+				},
+			},
+		);
+		await new Promise((resolve) => setTimeout(resolve, 10));
+		expect(started).toBe(1);
+		releaseStart();
+		const [, mountResponse] = await Promise.all([bindingCall, mountCall]);
+		expect(mountResponse.status).toBe(200);
+		await mountResponse.arrayBuffer();
+		expect(started).toBe(1);
+		for (const hook of getSandboxDisposeHooks(options)) await hook();
+	});
+
+	test("reports startup failures and retries on the next operation", async () => {
+		let started = 0;
+		const options = await resolveSandboxOptions({
+			sandbox: {
+				provider: {
+					start: async () => {
+						started += 1;
+						if (started === 1) throw new Error("provider unavailable");
+						return {
+							listProcesses: async () => ({ processes: [] }),
+							dispose: async () => {},
+						} as never;
+					},
+				},
+			},
+		} as never);
+		const execute = options.bindings?.[0]?.bindings["list-processes"].execute;
+		if (!execute) throw new Error("sandbox list-processes binding is missing");
+		await expect(execute({})).rejects.toEqual(
+			expect.objectContaining({
+				name: SandboxStartupError.name,
+				message: expect.stringContaining("provider unavailable"),
+			}),
+		);
+		await expect(execute({})).resolves.toEqual({ processes: [] });
+		expect(started).toBe(2);
+		for (const hook of getSandboxDisposeHooks(options)) await hook();
+	});
+
+	test("restarts an idle provider without changing the mount endpoint", async () => {
+		let started = 0;
+		let disposed = 0;
+		const options = await resolveSandboxOptions({
+			sandbox: {
+				idleTimeoutMs: 10,
+				provider: {
+					start: async () => {
+						started += 1;
+						return {
+							listProcesses: async () => ({ processes: [] }),
+							dispose: async () => {
+								disposed += 1;
+							},
+						} as never;
+					},
+				},
+			},
+		} as never);
+		const mount = options.mounts?.[0];
+		if (!mount || !("plugin" in mount)) {
+			throw new Error("sandbox mount config is missing");
+		}
+		const relayUrl = mount.plugin.config.baseUrl;
+		const execute = options.bindings?.[0]?.bindings["list-processes"].execute;
+		if (!execute) throw new Error("sandbox list-processes binding is missing");
+		await execute({});
+		for (let attempt = 0; attempt < 50 && disposed === 0; attempt++) {
+			await new Promise((resolve) => setTimeout(resolve, 5));
+		}
 		expect(disposed).toBe(1);
+		await execute({});
+		expect(started).toBe(2);
+		expect(mount.plugin.config.baseUrl).toBe(relayUrl);
+		for (const hook of getSandboxDisposeHooks(options)) await hook();
+	});
+
+	test("validates sandbox relay and lifecycle limits", async () => {
+		for (const [field, value] of [
+			["maxRelayRequests", 0],
+			["idleTimeoutMs", -1],
+			["startupTimeoutMs", 1.5],
+		] as const) {
+			await expect(
+				resolveSandboxOptions({
+					sandbox: {
+						client: { baseUrl: "http://127.0.0.1:1234" } as never,
+						[field]: value,
+					},
+				} as never),
+			).rejects.toThrow(new RegExp(`sandbox\\.${field}`));
+		}
 	});
 
 	test("does not start a provider when VM option validation fails", async () => {

--- a/packages/core/tests/options-schema.test.ts
+++ b/packages/core/tests/options-schema.test.ts
@@ -277,6 +277,107 @@ describe("AgentOsOptions validation", () => {
 		for (const hook of getSandboxDisposeHooks(options)) await hook();
 	});
 
+	test("times out startup, retries, and disposes a client that arrives late", async () => {
+		let started = 0;
+		let releaseFirstStart!: (client: unknown) => void;
+		const firstStart = new Promise<unknown>((resolve) => {
+			releaseFirstStart = resolve;
+		});
+		let lateDisposals = 0;
+		let activeDisposals = 0;
+		const options = await resolveSandboxOptions({
+			sandbox: {
+				startupTimeoutMs: 10,
+				provider: {
+					start: async () => {
+						started += 1;
+						if (started === 1) return await firstStart;
+						return {
+							listProcesses: async () => ({ processes: [] }),
+							dispose: async () => {
+								activeDisposals += 1;
+							},
+						} as never;
+					},
+				},
+			},
+		} as never);
+		const execute = options.bindings?.[0]?.bindings["list-processes"].execute;
+		if (!execute) throw new Error("sandbox list-processes binding is missing");
+
+		await expect(execute({})).rejects.toEqual(
+			expect.objectContaining({
+				name: SandboxStartupError.name,
+				message: expect.stringContaining("sandbox.startupTimeoutMs=10"),
+			}),
+		);
+		await expect(execute({})).resolves.toEqual({ processes: [] });
+		expect(started).toBe(2);
+
+		releaseFirstStart({
+			dispose: async () => {
+				lateDisposals += 1;
+			},
+		});
+		for (let attempt = 0; attempt < 50 && lateDisposals === 0; attempt++) {
+			await new Promise((resolve) => setTimeout(resolve, 5));
+		}
+		expect(lateDisposals).toBe(1);
+		for (const hook of getSandboxDisposeHooks(options)) await hook();
+		expect(activeDisposals).toBe(1);
+	});
+
+	test("waits for an idle client shutdown before starting its replacement", async () => {
+		let started = 0;
+		let markIdleDisposalStarted!: () => void;
+		const idleDisposalStarted = new Promise<void>((resolve) => {
+			markIdleDisposalStarted = resolve;
+		});
+		let releaseIdleDisposal!: () => void;
+		const idleDisposalGate = new Promise<void>((resolve) => {
+			releaseIdleDisposal = resolve;
+		});
+		const options = await resolveSandboxOptions({
+			sandbox: {
+				idleTimeoutMs: 10,
+				provider: {
+					start: async () => {
+						started += 1;
+						const generation = started;
+						return {
+							listProcesses: async () => ({
+								processes: [{ id: String(generation) }],
+							}),
+							dispose: async () => {
+								if (generation === 1) {
+									markIdleDisposalStarted();
+									await idleDisposalGate;
+								}
+							},
+						} as never;
+					},
+				},
+			},
+		} as never);
+		const execute = options.bindings?.[0]?.bindings["list-processes"].execute;
+		if (!execute) throw new Error("sandbox list-processes binding is missing");
+
+		await expect(execute({})).resolves.toEqual({
+			processes: [expect.objectContaining({ id: "1" })],
+		});
+		await idleDisposalStarted;
+		const racedOperation = execute({});
+		await new Promise((resolve) => setTimeout(resolve, 10));
+		expect(started).toBe(1);
+
+		releaseIdleDisposal();
+		await expect(racedOperation).resolves.toEqual({
+			processes: [expect.objectContaining({ id: "2" })],
+		});
+		expect(started).toBe(2);
+		for (const hook of getSandboxDisposeHooks(options)) await hook();
+	});
+
 	test("restarts an idle provider without changing the mount endpoint", async () => {
 		let started = 0;
 		let disposed = 0;
@@ -329,6 +430,30 @@ describe("AgentOsOptions validation", () => {
 				} as never),
 			).rejects.toThrow(new RegExp(`sandbox\\.${field}`));
 		}
+	});
+
+	test("aggregates sandbox configuration and cleanup failures", async () => {
+		let caught: unknown;
+		try {
+			await resolveSandboxOptions({
+				sandbox: {
+					client: { baseUrl: "http://127.0.0.1:1234" } as never,
+					dispose: async () => {
+						throw new Error("client cleanup failed");
+					},
+					maxRelayRequests: 0,
+				},
+			} as never);
+		} catch (error) {
+			caught = error;
+		}
+		expect(caught).toBeInstanceOf(AggregateError);
+		const errors = (caught as AggregateError).errors;
+		expect(errors).toHaveLength(2);
+		expect(errors.map((error) => String(error))).toEqual([
+			expect.stringContaining("sandbox.maxRelayRequests"),
+			expect.stringContaining("client cleanup failed"),
+		]);
 	});
 
 	test("does not start a provider when VM option validation fails", async () => {

--- a/packages/core/tests/public-api-exports.test.ts
+++ b/packages/core/tests/public-api-exports.test.ts
@@ -106,13 +106,16 @@ describe("root public API exports", () => {
 			defaultSoftware: false,
 		});
 		expect(KernelError).toBeTypeOf("function");
-		expect(SandboxStartupError).toBeTypeOf("function");
 		expect(createSnapshotExport).toBeTypeOf("function");
 		// Package dirs are the public software descriptor.
 		expect(defineSoftware("/opt/pkg")).toBe("/opt/pkg");
 		expect(isPackageDescriptor).toBeTypeOf("function");
 		expect(OPT_AGENTOS_ROOT).toBe("/opt/agentos");
 		expect(OPT_AGENTOS_BIN).toBe("/opt/agentos/bin");
+	});
+
+	test("re-exports sandbox lifecycle errors from the root entrypoint", () => {
+		expect(SandboxStartupError).toBeTypeOf("function");
 	});
 
 	test("re-exports current public SDK types from the root entrypoint", () => {

--- a/packages/core/tests/public-api-exports.test.ts
+++ b/packages/core/tests/public-api-exports.test.ts
@@ -40,6 +40,7 @@ import {
 	type PromptResult,
 	parseAgentOsOptions,
 	rootFilesystemConfigSchema,
+	SandboxStartupError,
 	type SessionCapabilities,
 	type SessionInfo,
 	type SessionStreamEntry,
@@ -105,6 +106,7 @@ describe("root public API exports", () => {
 			defaultSoftware: false,
 		});
 		expect(KernelError).toBeTypeOf("function");
+		expect(SandboxStartupError).toBeTypeOf("function");
 		expect(createSnapshotExport).toBeTypeOf("function");
 		// Package dirs are the public software descriptor.
 		expect(defineSoftware("/opt/pkg")).toBe("/opt/pkg");

--- a/packages/core/tests/sandbox-relay.test.ts
+++ b/packages/core/tests/sandbox-relay.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, test, vi } from "vitest";
+import type { AgentOsSandboxClient } from "../src/sandbox.js";
+import {
+	createSandboxRelay,
+	type SandboxRelay,
+	type SandboxRelayClientController,
+} from "../src/sandbox-relay.js";
+
+function staticController(
+	getClient: () => AgentOsSandboxClient,
+): SandboxRelayClientController {
+	return {
+		withClient: (operation) => operation(getClient()),
+	};
+}
+
+function authenticatedFetch(
+	relay: SandboxRelay,
+	path: string,
+	init: RequestInit = {},
+): Promise<Response> {
+	const headers = new Headers(init.headers);
+	headers.set("authorization", `Bearer ${relay.token}`);
+	return fetch(`${relay.baseUrl}${path}`, {
+		...init,
+		headers,
+		redirect: "manual",
+	});
+}
+
+describe("sandbox filesystem relay", () => {
+	test("requires its bearer token and exposes only native filesystem routes", async () => {
+		const request = vi.fn(async () => new Response("upstream"));
+		const relay = await createSandboxRelay({
+			controller: staticController(
+				() => ({ request }) as unknown as AgentOsSandboxClient,
+			),
+		});
+		try {
+			const unauthenticated = await fetch(
+				`${relay.baseUrl}/v1/fs/stat?path=%2F`,
+			);
+			expect(unauthenticated.status).toBe(401);
+			expect(await unauthenticated.json()).toEqual(
+				expect.objectContaining({
+					title: "Unauthorized",
+					status: 401,
+				}),
+			);
+
+			const wrongToken = await fetch(`${relay.baseUrl}/v1/fs/stat?path=%2F`, {
+				headers: { authorization: "Bearer wrong-token" },
+			});
+			expect(wrongToken.status).toBe(401);
+
+			const unknownRoute = await authenticatedFetch(relay, "/v1/processes");
+			expect(unknownRoute.status).toBe(404);
+			expect(await unknownRoute.json()).toEqual(
+				expect.objectContaining({
+					title: "Not Found",
+					status: 404,
+				}),
+			);
+			expect(request).not.toHaveBeenCalled();
+		} finally {
+			await relay.dispose();
+		}
+	});
+
+	test("resolves upstream authentication and custom headers for every client generation", async () => {
+		const seen: Array<{
+			path: string;
+			redirect: RequestRedirect | undefined;
+			headers: Headers;
+		}> = [];
+		const makeClient = (
+			token: string,
+			defaultHeaders: Record<string, string>,
+		): AgentOsSandboxClient =>
+			({
+				token,
+				defaultHeaders,
+				request: async (path: string, init?: RequestInit) => {
+					seen.push({
+						path,
+						redirect: init?.redirect,
+						headers: new Headers(init?.headers),
+					});
+					return new Response(null, {
+						status: 307,
+						headers: { location: "/v1/fs/stat?path=%2Fredirected" },
+					});
+				},
+			}) as unknown as AgentOsSandboxClient;
+
+		let client = makeClient("first-token", {
+			"x-generation": "first",
+			"x-retired-header": "first-only",
+		});
+		const relay = await createSandboxRelay({
+			controller: staticController(() => client),
+		});
+		try {
+			const first = await authenticatedFetch(
+				relay,
+				"/v1/fs/stat?path=%2Ffirst",
+				{ headers: { range: "bytes=0-3" } },
+			);
+			expect(first.status).toBe(307);
+			expect(first.headers.get("location")).toBe(
+				"/v1/fs/stat?path=%2Fredirected",
+			);
+
+			client = makeClient("second-token", { "x-generation": "second" });
+			const second = await authenticatedFetch(
+				relay,
+				"/v1/fs/stat?path=%2Fsecond",
+			);
+			expect(second.status).toBe(307);
+
+			expect(seen).toHaveLength(2);
+			expect(seen[0]?.path).toBe("/v1/fs/stat?path=%2Ffirst");
+			expect(seen[0]?.redirect).toBe("manual");
+			expect(seen[0]?.headers.get("authorization")).toBe("Bearer first-token");
+			expect(seen[0]?.headers.get("x-generation")).toBe("first");
+			expect(seen[0]?.headers.get("x-retired-header")).toBe("first-only");
+			expect(seen[0]?.headers.get("range")).toBe("bytes=0-3");
+			expect(seen[1]?.path).toBe("/v1/fs/stat?path=%2Fsecond");
+			expect(seen[1]?.headers.get("authorization")).toBe("Bearer second-token");
+			expect(seen[1]?.headers.get("x-generation")).toBe("second");
+			expect(seen[1]?.headers.get("x-retired-header")).toBeNull();
+		} finally {
+			await relay.dispose();
+		}
+	});
+
+	test("bounds concurrent requests and streams the accepted response", async () => {
+		let markEntered!: () => void;
+		const entered = new Promise<void>((resolve) => {
+			markEntered = resolve;
+		});
+		let releaseResponse!: (response: Response) => void;
+		const request = vi.fn(async () => {
+			markEntered();
+			return await new Promise<Response>((resolve) => {
+				releaseResponse = resolve;
+			});
+		});
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const relay = await createSandboxRelay({
+			controller: staticController(
+				() => ({ request }) as unknown as AgentOsSandboxClient,
+			),
+			maxConcurrentRequests: 1,
+		});
+		try {
+			const accepted = authenticatedFetch(
+				relay,
+				"/v1/fs/stat?path=%2Faccepted",
+			);
+			await entered;
+
+			const rejected = await authenticatedFetch(
+				relay,
+				"/v1/fs/stat?path=%2Frejected",
+			);
+			expect(rejected.status).toBe(429);
+			expect(await rejected.json()).toEqual(
+				expect.objectContaining({
+					title: "Sandbox relay capacity exceeded",
+					detail: expect.stringContaining("sandbox.maxRelayRequests=1"),
+				}),
+			);
+
+			const encoder = new TextEncoder();
+			const stream = new ReadableStream<Uint8Array>({
+				start(controller) {
+					controller.enqueue(encoder.encode("first-"));
+					setTimeout(() => {
+						controller.enqueue(encoder.encode("second"));
+						controller.close();
+					}, 5);
+				},
+			});
+			releaseResponse(
+				new Response(stream, {
+					headers: { "content-type": "application/octet-stream" },
+				}),
+			);
+			const acceptedResponse = await accepted;
+			expect(acceptedResponse.status).toBe(200);
+			expect(await acceptedResponse.text()).toBe("first-second");
+			expect(request).toHaveBeenCalledTimes(1);
+			expect(warn).toHaveBeenCalledWith(
+				"agentOS sandbox relay near sandbox.maxRelayRequests: 1/1",
+			);
+		} finally {
+			warn.mockRestore();
+			await relay.dispose();
+		}
+	});
+
+	test("streams request bodies to the active client", async () => {
+		let upstreamBody = "";
+		const request = vi.fn(async (_path: string, init?: RequestInit) => {
+			upstreamBody = await new Response(init?.body as never).text();
+			return new Response(`received:${upstreamBody}`);
+		});
+		const relay = await createSandboxRelay({
+			controller: staticController(
+				() => ({ request }) as unknown as AgentOsSandboxClient,
+			),
+		});
+		try {
+			const response = await authenticatedFetch(
+				relay,
+				"/v1/fs/file?path=%2Fupload.txt",
+				{
+					method: "PUT",
+					body: "streamed-upload",
+				},
+			);
+			expect(response.status).toBe(200);
+			expect(await response.text()).toBe("received:streamed-upload");
+			expect(upstreamBody).toBe("streamed-upload");
+		} finally {
+			await relay.dispose();
+		}
+	});
+});

--- a/website/public/docs/docs/sandboxes.md
+++ b/website/public/docs/docs/sandboxes.md
@@ -44,9 +44,9 @@ npm install @rivet-dev/agentos-sandbox sandbox-agent
 
 - `createSandboxFs`, `createSandboxBindings` — from `@rivet-dev/agentos-sandbox`.
 - `SandboxAgent` + provider helpers (e.g. `docker`) — from `sandbox-agent`.
-- Pass a provider as `sandbox: { provider: docker() }`. agentOS starts the
-  client, mounts it at `/mnt/sandbox`, registers process bindings, and disposes
-  it with the VM.
+- Pass a provider as `sandbox: { provider: docker() }`. agentOS mounts it at
+  `/mnt/sandbox`, registers process bindings, starts the sandbox on first use,
+  and disposes it with the VM.
 - In RivetKit actors, pass the provider to `agentOS(...)` — a fresh client per
   actor VM.
 
@@ -62,6 +62,15 @@ accepts these options alongside `provider` or `client`:
 | `readOnly` | Prevents the VM from modifying files through the mount. Defaults to `false`. |
 | `timeoutMs` | Sets the per-request timeout for Sandbox Agent filesystem calls. |
 | `maxFullReadBytes` | Bounds files buffered by full-read and truncate fallbacks. |
+| `idleTimeoutMs` | Stops an inactive provider sandbox so the next operation starts a fresh one. Defaults to five minutes; set to `0` to disable. |
+| `startupTimeoutMs` | Bounds provider startup. Defaults to 20 seconds; set to `0` to disable. |
+| `maxRelayRequests` | Bounds concurrent filesystem requests through the per-VM relay. Defaults to 64. |
+
+The native mount talks to a stable, authenticated loopback endpoint owned by
+that agentOS VM. When an idle sandbox is recreated or resumed with a different
+provider URL or token, the mount and process bindings switch to the current
+client without remounting or rebooting the VM. Concurrent first operations
+share one provider startup.
 
 The server example above changes `mountPath` to
 `/home/agentos/sandbox`. Paths used inside the external sandbox remain relative
@@ -112,8 +121,12 @@ additional provider SDK.
 
 For another backend, adapt any [Sandbox Agent](https://sandboxagent.dev)
 provider with `sandboxAgentProvider` from `@rivet-dev/agentos-sandbox`. Provider
-mode is the preferred lifecycle: each VM gets a fresh sandbox, and disposal of
-the VM destroys it.
+mode is the preferred lifecycle: each VM gets a fresh sandbox on first use,
+inactive sandboxes are replaced transparently, and disposal of the VM destroys
+the current sandbox. A process ID belongs to the sandbox generation that
+created it and is not valid after a destroy-and-recreate cycle. Providers that
+pause and reconnect may preserve their provider sandbox ID, but callers must
+not assume that the network address or credentials remain unchanged.
 
 ## Advanced: mount an existing client
 
@@ -121,7 +134,9 @@ Standalone `AgentOs.create()` can mount an already-connected,
 Sandbox-Agent-compatible client. Install `sandbox-agent` directly for this
 manual path. The caller owns the client by default; set `dispose` to `true` when
 the client implements disposal, or provide a callback to transfer lifecycle
-ownership to the VM.
+ownership to the VM. A custom compatible client must expose either a
+serializable `baseUrl` plus its current token/headers or an authenticated
+`request(path, init)` transport so the native mount relay can reach it.
 
 RivetKit `agentOS()` intentionally rejects the `client` form because one client
 cannot be shared safely across actor VMs. Pass a `provider` there so every actor

--- a/website/src/content/docs/docs/sandboxes.mdx
+++ b/website/src/content/docs/docs/sandboxes.mdx
@@ -46,9 +46,9 @@ npm install @rivet-dev/agentos-sandbox sandbox-agent
 
 - `createSandboxFs`, `createSandboxBindings` — from `@rivet-dev/agentos-sandbox`.
 - `SandboxAgent` + provider helpers (e.g. `docker`) — from `sandbox-agent`.
-- Pass a provider as `sandbox: { provider: docker() }`. agentOS starts the
-  client, mounts it at `/mnt/sandbox`, registers process bindings, and disposes
-  it with the VM.
+- Pass a provider as `sandbox: { provider: docker() }`. agentOS mounts it at
+  `/mnt/sandbox`, registers process bindings, starts the sandbox on first use,
+  and disposes it with the VM.
 - In RivetKit actors, pass the provider to `agentOS(...)` — a fresh client per
   actor VM.
 
@@ -68,6 +68,15 @@ accepts these options alongside `provider` or `client`:
 | `readOnly` | Prevents the VM from modifying files through the mount. Defaults to `false`. |
 | `timeoutMs` | Sets the per-request timeout for Sandbox Agent filesystem calls. |
 | `maxFullReadBytes` | Bounds files buffered by full-read and truncate fallbacks. |
+| `idleTimeoutMs` | Stops an inactive provider sandbox so the next operation starts a fresh one. Defaults to five minutes; set to `0` to disable. |
+| `startupTimeoutMs` | Bounds provider startup. Defaults to 20 seconds; set to `0` to disable. |
+| `maxRelayRequests` | Bounds concurrent filesystem requests through the per-VM relay. Defaults to 64. |
+
+The native mount talks to a stable, authenticated loopback endpoint owned by
+that agentOS VM. When an idle sandbox is recreated or resumed with a different
+provider URL or token, the mount and process bindings switch to the current
+client without remounting or rebooting the VM. Concurrent first operations
+share one provider startup.
 
 The server example above changes `mountPath` to
 `/home/agentos/sandbox`. Paths used inside the external sandbox remain relative
@@ -120,8 +129,12 @@ additional provider SDK.
 
 For another backend, adapt any [Sandbox Agent](https://sandboxagent.dev)
 provider with `sandboxAgentProvider` from `@rivet-dev/agentos-sandbox`. Provider
-mode is the preferred lifecycle: each VM gets a fresh sandbox, and disposal of
-the VM destroys it.
+mode is the preferred lifecycle: each VM gets a fresh sandbox on first use,
+inactive sandboxes are replaced transparently, and disposal of the VM destroys
+the current sandbox. A process ID belongs to the sandbox generation that
+created it and is not valid after a destroy-and-recreate cycle. Providers that
+pause and reconnect may preserve their provider sandbox ID, but callers must
+not assume that the network address or credentials remain unchanged.
 
 ## Advanced: mount an existing client
 
@@ -129,7 +142,9 @@ Standalone `AgentOs.create()` can mount an already-connected,
 Sandbox-Agent-compatible client. Install `sandbox-agent` directly for this
 manual path. The caller owns the client by default; set `dispose` to `true` when
 the client implements disposal, or provide a callback to transfer lifecycle
-ownership to the VM.
+ownership to the VM. A custom compatible client must expose either a
+serializable `baseUrl` plus its current token/headers or an authenticated
+`request(path, init)` transport so the native mount relay can reach it.
 
 <CodeSnippet file="examples/sandbox/existing-client.ts" />
 


### PR DESCRIPTION
- Add a stable authenticated per-VM relay for native sandbox filesystem mounts.
- Share lazy single-flight lifecycle state between filesystem and process binding operations, including idle replacement and credential rotation.
- Add replacement coverage and document the updated sandbox lifecycle.

Closes #1826