### PR TITLE
fix(core): keep spawned process stdin open

### DIFF
--- a/packages/core/src/agent-os.ts
+++ b/packages/core/src/agent-os.ts
@@ -4596,6 +4596,7 @@ export class AgentOs {
 			env: options.env,
 			stdin: options.stdin,
 			timeout: options.timeoutMs,
+			streamStdin: true,
 			onStdout: (data) => {
 				recordOutput("stdout", data);
 				options?.onStdout?.(data);


### PR DESCRIPTION
- Keep process stdin writable after `process.spawn` returns
- Preserve the existing streaming output and process lifecycle behavior