### PR TITLE
feat: add OrcaRouter to the default LLM egress allowlist

### DIFF
--- a/crates/client/src/agent_os.rs
+++ b/crates/client/src/agent_os.rs
@@ -1250,6 +1250,7 @@ const DEFAULT_EGRESS_HOSTS: &[&str] = &[
     "api.openai.com",
     "generativelanguage.googleapis.com",
     "openrouter.ai",
+    "api.orcarouter.ai",
 ];
 
 /// Resource patterns for the default egress allowlist. Network permission
@@ -3886,6 +3887,8 @@ mod tests {
         assert!(patterns.contains(&"dns://api.openai.com".to_string()));
         assert!(patterns.contains(&"dns://generativelanguage.googleapis.com".to_string()));
         assert!(patterns.contains(&"dns://openrouter.ai".to_string()));
+        assert!(patterns.contains(&"dns://api.orcarouter.ai".to_string()));
+        assert!(patterns.contains(&"tcp://api.orcarouter.ai:*".to_string()));
     }
 
     #[test]

--- a/docs/content/docs/agents/opencode.mdx
+++ b/docs/content/docs/agents/opencode.mdx
@@ -21,6 +21,7 @@ OpenCode auto-detects a provider when its key is present on the session's `env`,
 - `ANTHROPIC_API_KEY` — Anthropic (Claude), the default.
 - `OPENAI_API_KEY` — OpenAI.
 - `OPENROUTER_API_KEY` — OpenRouter.
+- `ORCAROUTER_API_KEY`. Set this to use [OrcaRouter](https://www.orcarouter.ai), an OpenAI-compatible gateway that routes requests to the best available model.
 - `GEMINI_API_KEY` — Google Gemini.
 - `GROQ_API_KEY` — Groq.
 - …plus Amazon Bedrock, Azure, Google Vertex, and 70+ providers via [models.dev](https://models.dev).

--- a/docs/content/docs/agents/pi.mdx
+++ b/docs/content/docs/agents/pi.mdx
@@ -19,7 +19,7 @@ Read [Sessions](/agentos/docs/sessions) first for session options, streaming eve
 Set the relevant variable on the session's `env`, sourced from your server's environment:
 
 - `ANTHROPIC_API_KEY` — Anthropic (Claude), the default.
-- Other providers — use the provider-named key (e.g. `OPENAI_API_KEY`, `GEMINI_API_KEY`, `OPENROUTER_API_KEY`).
+- Other providers — use the provider-named key (e.g. `OPENAI_API_KEY`, `GEMINI_API_KEY`, `OPENROUTER_API_KEY`, `ORCAROUTER_API_KEY`).
 
 See [Models & Credentials](/agentos/docs/models-and-credentials), and Pi's [providers docs](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/docs/providers.md) for the full list.
 


### PR DESCRIPTION
## What

Add [OrcaRouter](https://www.orcarouter.ai) to the default LLM egress allowlist, so a VM can reach the OrcaRouter gateway with zero extra network configuration (same as the existing `openrouter.ai` entry).

It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

OrcaRouter serves both OpenAI-compatible (`/v1/chat/completions`) and Anthropic-compatible (`/v1/messages`) surfaces, so it works for the Claude, Codex, Pi, and OpenCode agents without any per-agent wiring.

## Changes

- Add `api.orcarouter.ai` to `DEFAULT_EGRESS_HOSTS` in `crates/client/src/agent_os.rs` (both `dns://` and `tcp://` patterns are generated automatically).
- Update the default-network-egress unit test to assert the new host.
- Document `ORCAROUTER_API_KEY` on the OpenCode and Pi agent pages.

## Validation

- `cargo test -p agentos-client --lib`: 45 passed (includes the updated egress allowlist test).
- `cargo check -p agentos-client`: clean.
- `cargo fmt -p agentos-client -- --check`: clean.
- `cargo clippy -p agentos-client --lib`: clean (pre-existing e2e test clippy warnings on the base branch are unrelated).
- Live: `POST https://api.orcarouter.ai/v1/chat/completions` (Bearer) and `POST https://api.orcarouter.ai/v1/messages` (x-api-key) both return 200 with real model routing.

Disclosure: I'm an engineer on the OrcaRouter team.
