### PR TITLE
fix(runtime): propagate unexpected errno from realpathSync

### DIFF
--- a/packages/build-tools/bridge-src/builtins/fs.ts
+++ b/packages/build-tools/bridge-src/builtins/fs.ts
@@ -4032,13 +4032,11 @@ var fs = {
           const err = e;
           if (err.code === "ELOOP") throw e;
           if (err.code === "ENOENT" || err.code === "ENOTDIR") {
-            const enoent = new Error(`ENOENT: no such file or directory, realpath '${raw}'`);
-            enoent.code = "ENOENT";
-            enoent.syscall = "realpath";
-            enoent.path = raw;
-            throw enoent;
+            throw createFsError("ENOENT", `ENOENT: no such file or directory, realpath '${raw}'`, "realpath", raw);
           }
-          break;
+          // Any other errno must reach the caller: returning here handed back the
+          // partially resolved prefix as if it were the real path.
+          throwNormalizedFsBridgeError(err, "realpath", raw);
         }
       }
       return "/" + resolved.join("/") || "/";


### PR DESCRIPTION
Closes #1838.

- The bridge's `realpathSync` segment loop special-cased `ELOOP`/`ENOENT`/`ENOTDIR` and `break`-ed on every other errno, then returned the partially resolved prefix as if it were the resolved path. Callers got a valid-looking wrong path — typically the parent directory — instead of the failure.
- Unexpected errnos now go through the existing `throwNormalizedFsBridgeError`, so `EACCES` and friends reach the guest with the right code, `errno`, `syscall` and `path`.
- The `ENOENT` branch now uses `createFsError` instead of hand-rolling the error, which also gives it the `errno` field it was missing.

Verified against the real resolution loop with the host `lstat` stubbed, before and after:

```
=== BEFORE ===
  realpathSync("/ok/file.txt")                 -> "/ok/file.txt"
  realpathSync("/blocked/secret.txt")          -> "/blocked/secret.txt"
  realpathSync("/blocked/sub/deep/secret.txt") -> "/blocked/sub"
  realpathSync("/missing/x")                   threw ENOENT errno=undefined

=== AFTER ===
  realpathSync("/ok/file.txt")                 -> "/ok/file.txt"
  realpathSync("/blocked/secret.txt")          threw EACCES errno=-13 syscall=realpath
  realpathSync("/blocked/sub/deep/secret.txt") threw EACCES errno=-13 syscall=realpath
  realpathSync("/missing/x")                   threw ENOENT errno=-2
```

The third line is the reported symptom: a directory path returned where a file was requested, which is what surfaced as `EISDIR` in the Claude CLI.

I did not add a committed regression test — the only home I found for guest `fs` semantics is a VM-level suite I can't run locally (no Rust toolchain on this machine). Happy to add one if you point me at the harness you'd want it in.