### PR TITLE
fix(runtime): prefer host type flags over mode bits in Stats

### DIFF
--- a/packages/build-tools/bridge-src/builtins/fs.ts
+++ b/packages/build-tools/bridge-src/builtins/fs.ts
@@ -15,6 +15,20 @@ var O_EXCL = 128;
 var O_TRUNC = 512;
 var O_APPEND = 1024;
 var KERNEL_POLLIN = 1;
+// Host stat payloads carry explicit `isDirectory` / `isSymbolicLink` flags that
+// reflect what the VFS actually resolved. Prefer them over the mode bits, which
+// can disagree on backends with stale attribute caches (e.g. NFS/EFS), and fall
+// back to the mode bits when a backend omits the hints.
+function resolveStatFormat(init) {
+  const fmt = init.mode & 61440;
+  const isDir = typeof init.isDirectory === "boolean" ? init.isDirectory : void 0;
+  const isLink = typeof init.isSymbolicLink === "boolean" ? init.isSymbolicLink : void 0;
+  if (isLink === true) return 40960;
+  if (isDir === true) return 16384;
+  if (isDir === false && fmt === 16384) return 32768;
+  if (isLink === false && fmt === 40960) return 32768;
+  return fmt;
+}
 var Stats = class {
   dev;
   ino;
@@ -56,27 +70,31 @@ var Stats = class {
     this.mtime = new Date(this.mtimeMs);
     this.ctime = new Date(this.ctimeMs);
     this.birthtime = new Date(this.birthtimeMs);
+    Object.defineProperty(this, "_typeFormat", {
+      value: resolveStatFormat(init),
+      enumerable: false
+    });
   }
   isFile() {
-    return (this.mode & 61440) === 32768;
+    return this._typeFormat === 32768;
   }
   isDirectory() {
-    return (this.mode & 61440) === 16384;
+    return this._typeFormat === 16384;
   }
   isSymbolicLink() {
-    return (this.mode & 61440) === 40960;
+    return this._typeFormat === 40960;
   }
   isBlockDevice() {
-    return (this.mode & 61440) === 24576;
+    return this._typeFormat === 24576;
   }
   isCharacterDevice() {
-    return (this.mode & 61440) === 8192;
+    return this._typeFormat === 8192;
   }
   isFIFO() {
-    return (this.mode & 61440) === 4096;
+    return this._typeFormat === 4096;
   }
   isSocket() {
-    return (this.mode & 61440) === 49152;
+    return this._typeFormat === 49152;
   }
 };
 var Dirent = class {


### PR DESCRIPTION
Closes #1839.

- Every host stat payload already carries `isDirectory` and `isSymbolicLink` (`javascript_sync_rpc_stat_value`, `javascript_sync_rpc_host_stat_value`, `HostStat::to_value`), but `Stats` derived all seven type predicates from the mode bits alone. `Dirent`, right below it, already trusts its explicit boolean.
- The type is now resolved once in the constructor from the host flags, falling back to the mode bits when a backend omits them. A backend that sends no hints behaves exactly as it does today.
- Resolving a single format also keeps the predicates mutually exclusive, which mode bits plus a contradicting hint would not.

Behaviour of the real `Stats` class, before and after:

```
case                                   BEFORE           AFTER
--------------------------------------------------------------------------
regular file, host agrees              isFile           isFile
STALE CACHE: dir bit on a real file    isDirectory      isFile          <-- changed
real directory                         isDirectory      isDirectory
symlink                                isSymbolicLink   isSymbolicLink
STALE CACHE: file bit on a real dir    isFile           isDirectory     <-- changed
legacy backend, no hints (dir)         isDirectory      isDirectory
legacy backend, no hints (file)        isFile           isFile
fifo, hints both false                 isFIFO           isFIFO
```

Only the two cases where the mode bits contradict the host change, and both change to the host's answer. Row 2 is the reported failure: the Claude CLI's Edit tool seeing `EISDIR` on a regular file.

`_typeFormat` is defined non-enumerable, so `mode` is untouched and `JSON.stringify(stats)` / `Object.keys(stats)` are unchanged.

Same caveat as #1908 — no committed test, because the guest `fs` suites need a VM I can't build locally. Glad to add one wherever you'd want it.