### PR TITLE
docs(permissions): correct the network pattern form

### DIFF
--- a/crates/kernel/tests/permissions.rs
+++ b/crates/kernel/tests/permissions.rs
@@ -537,6 +537,37 @@ fn permission_glob_double_star_still_matches_nested_paths() {
 }
 
 #[test]
+fn network_permission_patterns_match_the_resource_uri_not_a_bare_host() {
+    // Network resources are formatted as URIs (`format_tcp_resource` /
+    // `format_dns_resource`), so a pattern is matched against the whole URI.
+    assert!(permission_glob_matches(
+        "tcp://api.example.com:443",
+        "tcp://api.example.com:443",
+    ));
+    assert!(permission_glob_matches(
+        "tcp://api.example.com:*",
+        "tcp://api.example.com:443",
+    ));
+    assert!(permission_glob_matches(
+        "dns://api.example.com",
+        "dns://api.example.com",
+    ));
+
+    // A bare host or `host:port` never matches, and a single `*` cannot reach
+    // past the `//`, so neither form can be used to allow or deny a host.
+    assert!(!permission_glob_matches(
+        "api.example.com",
+        "tcp://api.example.com:443",
+    ));
+    assert!(!permission_glob_matches(
+        "api.example.com:443",
+        "tcp://api.example.com:443",
+    ));
+    assert!(!permission_glob_matches("*", "tcp://api.example.com:443"));
+    assert!(!permission_glob_matches("*.example.com", "dns://api.example.com"));
+}
+
+#[test]
 fn kernel_vm_config_defaults_to_deny_all_permissions() {
     let mut kernel = KernelVm::new(MemoryFileSystem::new(), KernelVmConfig::new("vm-defaults"));
 

--- a/docs/content/docs/permissions.mdx
+++ b/docs/content/docs/permissions.mdx
@@ -77,7 +77,9 @@ To invert it, flip `default` to `"deny"` and allow just one subtree:
 
 ## Allow only specific network hosts
 
-Every non-`fs` scope matches by `patterns` instead of `paths`. For `network`, a pattern is a host (or `host:port`), and the operations are `fetch`, `http`, `dns`, and `listen`.
+Every non-`fs` scope matches by `patterns` instead of `paths`. The operations for `network` are `fetch`, `http`, `dns`, and `listen`.
+
+A `network` pattern is matched against the URI form of the connection, not a bare host: `tcp://<host>:<port>` for `fetch`, `http`, and `listen`, and `dns://<hostname>` for `dns`. Patterns are globs in which a single `*` does not cross `/`, so use `tcp://api.example.com:*` to allow every port on a host, and `tcp://**` to allow every host. A bare `api.example.com` matches nothing.
 
 <CodeSnippet file="examples/permissions/server.ts" region="allow-one-host" />
 

--- a/examples/permissions/server.ts
+++ b/examples/permissions/server.ts
@@ -15,11 +15,18 @@ const denyVault = {
 } satisfies Permissions;
 
 // docs:start allow-one-host
-// Deny the network by default, allow only api.example.com.
+// Deny the network by default, allow only api.example.com (any port).
+// Patterns match the URI form of the connection, so a bare host never matches.
 const allowOneHost = {
 	network: {
 		default: "deny",
-		rules: [{ mode: "allow", operations: ["*"], patterns: ["api.example.com"] }],
+		rules: [
+			{
+				mode: "allow",
+				operations: ["*"],
+				patterns: ["tcp://api.example.com:*", "dns://api.example.com"],
+			},
+		],
 	},
 } satisfies Permissions;
 // docs:end allow-one-host


### PR DESCRIPTION
Follow-up to #1884, where `network` rules were reported as inert in both directions. The rules are evaluated; they just never match.

- Network resources are built as URIs before the check — `format_tcp_resource` gives `tcp://{host}:{port}` for fetch/http/listen, `format_dns_resource` gives `dns://{hostname}` — and `permission_resource_matches` globs the pattern against that whole string with `permission_glob_matches`, where a single `*` does not cross `/`.
- `permissions.mdx` said a network pattern is "a host (or `host:port`)", and the shipped `allow-one-host` example used `patterns: ["api.example.com"]`. Neither form can ever match, so a documented allowlist denies everything and a documented blocklist permits every host.
- Documents the URI form, fixes the example to `tcp://api.example.com:*` / `dns://api.example.com`, and adds a kernel test pinning the semantics — the existing network-pattern coverage only uses the URI form, which is why CI stayed green while the documented form was broken.

Matcher behaviour against `tcp://api.example.com:443`, verified by porting `permission_glob_matches` byte-for-byte to JS and running the matrix:

```
tcp://api.example.com:443   yes    literal
tcp://api.example.com:*     yes    the * never has to cross a /
api.example.com             no     literal mismatch at index 0
api.example.com:443         no     same
*                           no     single * halts at the / in //
**                          yes    crosses separators
```

This only corrects the documentation to describe what the matcher does. If you would rather the matcher accept a bare `host` / `host:port` — which would make every policy written from the old docs start working — that is the alternative fix and I am happy to send it instead; I left the permission matcher alone since it is the security boundary.

I could not run `cargo test` locally (no Rust toolchain on this machine), so the added test needs CI. Every assertion in it was checked against the ported matcher first.