### PR TITLE
ci(release): migrate npm publishing to OIDC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,6 @@ jobs:
             npx turbo build \
               --only \
               --concurrency=4 \
-              --filter='!@rivet-dev/agentos-website' \
               --filter='!@agentos-software/codex' \
               --filter='!@rivet-dev/agentos-browser' \
               --filter='!@rivet-dev/agentos-runtime-browser' \

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -260,7 +260,7 @@ jobs:
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
           registry-url: https://registry.npmjs.org
-      - run: pnpm install --frozen-lockfile --filter='!@rivet-dev/agentos-website'
+      - run: pnpm install --frozen-lockfile
       - uses: actions/download-artifact@v4
         with:
           name: wasm-commands
@@ -310,7 +310,6 @@ jobs:
           # Browser support is retained in-tree but intentionally disabled until
           # it has a reactor/security design independent of the native sidecar.
           npx turbo build \
-            --filter='!@rivet-dev/agentos-website' \
             --filter='!@rivet-dev/agentos-browser' \
             --filter='!@rivet-dev/agentos-runtime-browser' \
             --filter='!@rivet-dev/agentos-playground' \
@@ -436,7 +435,7 @@ jobs:
           key: ${{ runner.os }}-x86_64-unknown-linux-gnu-rusty-v8-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-x86_64-unknown-linux-gnu-rusty-v8-
-      - run: pnpm install --frozen-lockfile --filter='!@rivet-dev/agentos-website'
+      - run: pnpm install --frozen-lockfile
       - name: Bump Cargo versions
         run: |
           pnpm --filter=publish exec tsx src/ci/bin.ts bump-versions \

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -248,6 +248,9 @@ jobs:
     name: Publish npm
     if: ${{ !cancelled() && needs.wasm-commands.result == 'success' && needs.codex-wasm.result == 'success' && needs.build-sidecar.result == 'success' && needs.build-sidecar-darwin.result == 'success' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -319,7 +322,7 @@ jobs:
             --version ${{ needs.context.outputs.version }}
       - name: Publish npm packages
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ""
         run: |
           pnpm --filter=publish exec tsx src/ci/bin.ts publish-npm \
             --tag ${{ needs.context.outputs.npm_tag }} \

--- a/scripts/publish/src/ci/bin.ts
+++ b/scripts/publish/src/ci/bin.ts
@@ -147,6 +147,10 @@ program
 		"--version-only",
 		"Only rewrite version fields without publish-time dependency injection",
 	)
+	.option(
+		"--repository <owner/repo>",
+		"GitHub repository recorded in publish-time package metadata (defaults to GITHUB_REPOSITORY)",
+	)
 	.option("--dry-run", "Do not write, only report")
 	.action(async (opts) => {
 		const repoRoot = findRepoRoot();
@@ -155,6 +159,7 @@ program
 		await bumpPackageJsons(repoRoot, version, {
 			dryRun: !!opts.dryRun,
 			versionOnly: !!opts.versionOnly,
+			repository: opts.repository ?? process.env.GITHUB_REPOSITORY,
 		});
 		await bumpCargoVersions(repoRoot, version, { dryRun: !!opts.dryRun });
 	});

--- a/scripts/publish/src/lib/version.test.ts
+++ b/scripts/publish/src/lib/version.test.ts
@@ -4,7 +4,11 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 import { DEFAULT_SIDECAR_PLATFORMS } from "./packages.js";
-import { bumpCargoVersions, bumpPackageJsons } from "./version.js";
+import {
+	bumpCargoVersions,
+	bumpPackageJsons,
+	githubRepositoryUrl,
+} from "./version.js";
 
 async function writeJson(root: string, rel: string, value: unknown) {
 	const path = join(root, rel);
@@ -105,7 +109,9 @@ test("bumpPackageJsons injects sidecar platform optional dependencies", async ()
 			});
 		}
 
-		await bumpPackageJsons(repoRoot, "0.3.0");
+		await bumpPackageJsons(repoRoot, "0.3.0", {
+			repository: "rivet-dev/agentos",
+		});
 
 		const sidecarManifest = JSON.parse(
 			await readFile(
@@ -129,6 +135,11 @@ test("bumpPackageJsons injects sidecar platform optional dependencies", async ()
 				"utf8",
 			),
 		);
+		assert.deepEqual(sidecarManifest.repository, {
+			type: "git",
+			url: "https://github.com/rivet-dev/agentos.git",
+			directory: "packages/sidecar-binary",
+		});
 		assert.deepEqual(
 			runtimeSidecarManifest.optionalDependencies,
 			Object.fromEntries(
@@ -178,6 +189,7 @@ test("bumpPackageJsons pins lockstep and independent AgentOS Apps runtimes", asy
 		}
 
 		await bumpPackageJsons(repoRoot, "0.0.0-preview.abc1234", {
+			repository: "rivet-dev/agentos",
 			resolveNpmLatestVersion: async (name) => {
 				assert.equal(name, "@agentos-software/tar");
 				return "0.3.5";
@@ -198,4 +210,16 @@ test("bumpPackageJsons pins lockstep and independent AgentOS Apps runtimes", asy
 	} finally {
 		await rm(repoRoot, { recursive: true, force: true });
 	}
+});
+
+test("githubRepositoryUrl validates owner/repo slugs", () => {
+	assert.equal(
+		githubRepositoryUrl("rivet-dev/agentos"),
+		"https://github.com/rivet-dev/agentos.git",
+	);
+	assert.throws(() => githubRepositoryUrl("rivet-dev"), /expected owner\/repo/);
+	assert.throws(
+		() => githubRepositoryUrl("https://github.com/rivet-dev/agentos"),
+		/expected owner\/repo/,
+	);
 });

--- a/scripts/publish/src/lib/version.ts
+++ b/scripts/publish/src/lib/version.ts
@@ -28,6 +28,11 @@ const log = scoped("version");
 interface PackageJson {
 	name?: string;
 	version?: string;
+	repository?: {
+		type: "git";
+		url: string;
+		directory: string;
+	};
 	dependencies?: Record<string, string>;
 	devDependencies?: Record<string, string>;
 	peerDependencies?: Record<string, string>;
@@ -97,6 +102,26 @@ export interface BumpOptions {
 	 * the publish-time mode used by CI — never committed.
 	 */
 	versionOnly?: boolean;
+	/** GitHub repository slug recorded in publish-time package metadata. */
+	repository?: string;
+}
+
+export function githubRepositoryUrl(repository: string): string {
+	if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repository)) {
+		throw new Error(
+			`invalid GitHub repository ${JSON.stringify(repository)}; expected owner/repo`,
+		);
+	}
+	return `https://github.com/${repository}.git`;
+}
+
+function requirePublishRepository(repository: string | undefined): string {
+	if (!repository) {
+		throw new Error(
+			"publish-time package metadata requires a GitHub repository",
+		);
+	}
+	return repository;
 }
 
 /**
@@ -171,6 +196,12 @@ export async function bumpPackageJsons(
 		pkgJson.version = version;
 
 		if (!versionOnly) {
+			pkgJson.repository = {
+				type: "git",
+				url: githubRepositoryUrl(requirePublishRepository(opts.repository)),
+				directory: pkg.relDir,
+			};
+
 			// Inject optionalDependencies on meta packages so end users get the
 			// correct platform-specific binary via npm's os/cpu/libc resolution.
 			const platformPkgs = metaPlatformMap.get(pkg.name);


### PR DESCRIPTION
- Grant the npm publish job permission to request a GitHub OIDC token.
- Publish without the repository npm token.
- Inject canonical repository metadata into every published package.