### PR TITLE
docs: remediate SEO audit findings

### DIFF
--- a/docs/content/docs/agent-to-agent.mdx
+++ b/docs/content/docs/agent-to-agent.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Agent-to-Agent Communication"
-description: "Use bindings to let agents communicate with each other."
+description: "Connect agents through agentOS bindings so one coding agent can call another while sessions, permissions, and results remain isolated."
 skill: true
 ---
 

--- a/docs/content/docs/agents/claude.mdx
+++ b/docs/content/docs/agents/claude.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Claude Code"
-description: "Run the Claude Code agent inside a VM with skills, MCP servers, and custom configuration."
+description: "Run Claude Code inside an agentOS VM with durable sessions, configurable skills, MCP servers, credentials, and filesystem access."
 skill: false
 ---
 

--- a/docs/content/docs/agents/codex.mdx
+++ b/docs/content/docs/agents/codex.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Codex"
-description: "Run the Codex coding agent inside a VM with skills, MCP servers, and custom configuration."
+seoTitle: "Run the Codex Coding Agent in agentOS"
+description: "Run Codex inside an agentOS VM with durable sessions, configurable skills, MCP servers, credentials, and filesystem access."
 skill: false
 ---
 

--- a/docs/content/docs/agents/custom.mdx
+++ b/docs/content/docs/agents/custom.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Custom Agents"
-description: "Bring your own coding agent to agentOS by speaking the Agent Client Protocol (ACP) inside the VM."
+description: "Integrate a custom coding agent with agentOS through the Agent Client Protocol, then configure its package, commands, and session behavior."
 ---
 
 A custom agent is a program that runs **inside the VM** to drive a coding agent. AgentOS spawns it when you call `openSession({ sessionId, agent })` and talks to it over the Agent Client Protocol. You ship it as a software package, exactly like the built-in agents.

--- a/docs/content/docs/agents/opencode.mdx
+++ b/docs/content/docs/agents/opencode.mdx
@@ -1,6 +1,6 @@
 ---
 title: "OpenCode"
-description: "Run the OpenCode coding agent inside a VM with skills, MCP servers, and custom configuration."
+description: "Run OpenCode inside an agentOS VM with durable sessions, configurable skills, MCP servers, credentials, and filesystem access."
 skill: false
 ---
 

--- a/docs/content/docs/agents/pi.mdx
+++ b/docs/content/docs/agents/pi.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Pi"
-description: "Run the Pi coding agent inside a VM with extensions and custom configuration."
+seoTitle: "Run the Pi Coding Agent in agentOS"
+description: "Run Pi inside an agentOS VM with durable sessions, extensions, custom configuration, provider credentials, and filesystem access."
 skill: true
 ---
 

--- a/docs/content/docs/approvals.mdx
+++ b/docs/content/docs/approvals.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Approvals"
-description: "Handle native ACP permission options with durable AgentOS correlation."
+description: "Handle Agent Client Protocol permission requests in agentOS, present durable approval choices, and correlate responses with active sessions."
 ---
 
 Set a session's immutable `permissionPolicy` when calling `openSession`:

--- a/docs/content/docs/architecture.mdx
+++ b/docs/content/docs/architecture.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Overview"
-description: "A high-level tour of how agentOS works: the client / server / VM picture, the anatomy of a Linux VM (kernel + executor), agents and sessions, and the Rivet Actor orchestration underneath."
+description: "Explore agentOS architecture from trusted clients and sidecars to isolated VMs, kernels, executors, coding-agent sessions, and Rivet Actor persistence."
 skill: true
 ---
 

--- a/docs/content/docs/architecture/agent-sdk-snapshots.mdx
+++ b/docs/content/docs/architecture/agent-sdk-snapshots.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Agent SDK Snapshots"
-description: "How an agent's SDK is evaluated once per sidecar into a V8 heap snapshot and reused across sessions instead of re-imported on every openSession: the bundle, the userland snapshot, the process-wide cache, pre-warm, per-session restore, isolation, and the snapshot-safety rules an SDK must follow."
+description: "Learn how agentOS evaluates a coding agent's SDK once, creates a reusable V8 heap snapshot, restores isolated sessions, and enforces snapshot safety."
 skill: true
 ---
 

--- a/docs/content/docs/architecture/agent-sessions.mdx
+++ b/docs/content/docs/architecture/agent-sessions.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Agent Sessions"
-description: "How durable sessions, ACP adapters, prompts, permissions, and history flow through AgentOS."
+description: "Understand how agentOS creates durable coding-agent sessions, connects ACP adapters, processes prompts, applies permissions, and stores history."
 skill: true
 ---
 

--- a/docs/content/docs/architecture/compiler-toolchain.mdx
+++ b/docs/content/docs/architecture/compiler-toolchain.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Compiler Toolchain"
-description: "How agentOS compiles its command suite to WebAssembly: Rust coreutils via cargo and C programs via wasi-sdk, linked against a patched wasi-libc plus the wasi-ext bindings, and how the resulting .wasm files become the guest's commands."
+description: "Learn how agentOS builds its command suite to WebAssembly with Rust, wasi-sdk, patched libc, host bindings, and packaged guest binaries."
 skill: true
 ---
 

--- a/docs/content/docs/architecture/filesystem.mdx
+++ b/docs/content/docs/architecture/filesystem.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Filesystem"
-description: "Internals of the kernel VFS: the overlay/mount/root engines, how guest fs syscalls are routed and confined, WASM preopens, and mount confinement against symlink and .. escapes."
+seoTitle: "agentOS Filesystem Architecture"
+description: "Explore the agentOS kernel VFS, layered mounts, guest syscall routing, WASM preopens, and protections against path and symlink escapes."
 skill: true
 ---
 

--- a/docs/content/docs/architecture/javascript-executor.mdx
+++ b/docs/content/docs/architecture/javascript-executor.mdx
@@ -1,6 +1,6 @@
 ---
 title: "JavaScript Executor & Socket Reactor"
-description: "How the process-wide Tokio runtime, bounded socket tasks, durable readiness state, capacity-one VM wakes, and thread-affine V8 executor cooperate without running guest JavaScript on Tokio."
+description: "Understand how agentOS coordinates Tokio socket tasks, durable readiness, bounded VM wakes, backpressure, and thread-affine V8 execution."
 skill: true
 ---
 

--- a/docs/content/docs/architecture/networking.mdx
+++ b/docs/content/docs/architecture/networking.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Networking"
-description: "How the kernel socket table works: a single VM-local transport that carries host, JavaScript, and WASM traffic, where fetch / net / dns route through it, how egress policy and loopback confinement are enforced, and how preview URLs are served."
+description: "Explore the agentOS kernel socket table, JavaScript and WASM traffic, DNS, egress policy, loopback isolation, and preview routing."
 skill: true
 ---
 

--- a/docs/content/docs/architecture/packages-and-command-resolution.mdx
+++ b/docs/content/docs/architecture/packages-and-command-resolution.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Packages & Command Resolution"
-description: "How software is packaged, linked, resolved, and executed in an agentOS VM: a package is a directory, resolution is a $PATH walk, and a file's header picks its runtime."
+seoTitle: "agentOS Package and Command Resolution"
+description: "Understand how agentOS packages software, projects commands into VM paths, resolves executables, and selects the runtime for each file."
 skill: true
 ---
 

--- a/docs/content/docs/architecture/sessions-persistence.mdx
+++ b/docs/content/docs/architecture/sessions-persistence.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Sessions & Persistence"
-description: "How AgentOS stores exact ACP history and restores adapters through VM SQLite."
+description: "Learn how agentOS stores exact Agent Client Protocol history in VM SQLite and restores adapters, sessions, and transcripts after wake."
 ---
 
 SQLite is the AgentOS source of truth for public session metadata, prompts, pending requests, and durable ACP events. Adapter-owned session files or databases remain private adapter state; AgentOS does not mirror them into the VFS or import adapter replay into public history.

--- a/docs/content/docs/authentication.mdx
+++ b/docs/content/docs/authentication.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Authentication"
-description: "Authenticate connections to agentOS actors using Rivet Actor connection params and hooks."
+description: "Authenticate connections to agentOS actors with Rivet Actor connection parameters and hooks, then carry trusted identity into sessions."
 skill: true
 ---
 

--- a/docs/content/docs/bash.mdx
+++ b/docs/content/docs/bash.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Bash"
-description: "Run shell commands and arbitrary argv operations through the agentOS execution lifecycle."
+seoTitle: "Run Bash Commands in agentOS VMs"
+description: "Run shell commands and arbitrary argument-vector operations through the agentOS execution lifecycle with controlled input, output, and exit status."
 skill: true
 ---
 

--- a/docs/content/docs/bindings.mdx
+++ b/docs/content/docs/bindings.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Custom Bindings"
-description: "Expose custom host functions to agents as CLI commands inside the VM."
+description: "Expose trusted host functions to agentOS coding agents as typed CLI commands, with scoped input, output, and execution behavior."
 skill: true
 ---
 

--- a/docs/content/docs/core.mdx
+++ b/docs/content/docs/core.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Direct VM API"
-description: "Use the direct AgentOS VM API or layer it into an AgentOS actor."
+description: "Use the direct agentOS VM API to create and control isolated execution environments, or compose it inside a Rivet Actor."
 skill: true
 ---
 
@@ -22,7 +22,7 @@ actor API.
 | Agent-to-agent | Custom | Built into [Rivet Actors](/agentos/docs/agent-to-agent) |
 | Authentication | Set up yourself | [Docs](/agentos/docs/authentication) |
 
-- Use [Rivet Actors](https://rivet.dev/docs/actors) for persistence,
+- Use [Rivet Actors](/actors/docs/) for persistence,
   networking, and orchestration.
 - Use `AgentOs.create()` for direct VM control in a Node.js process.
 - `agentOS()` returns an ordinary TypeScript Rivet actor definition — VM options

--- a/docs/content/docs/crash-course.mdx
+++ b/docs/content/docs/crash-course.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Crash Course"
-description: "Run coding agents inside isolated VMs with full filesystem, process, and network control."
+description: "Learn agentOS fundamentals by creating an isolated VM, launching a coding-agent session, sending prompts, and inspecting durable results."
 skill: true
 ---
 
@@ -26,7 +26,7 @@ agentOS is in preview and the API is subject to change. If you run into issues, 
 <CodeSnippet file="examples/crash-course/server.ts" title="server.ts" />
 </CodeGroup>
 
-After the quickstart, customize your agent with the [Registry](/registry).
+After the quickstart, customize your agent with the [Registry](/agentos/registry/).
 
 ## Agents
 

--- a/docs/content/docs/cron.mdx
+++ b/docs/content/docs/cron.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Crons & Loops"
-description: "Schedule recurring commands and agent sessions in agentOS VMs."
+description: "Schedule recurring commands and coding-agent sessions in agentOS VMs with durable loops that survive restarts, sleep, and worker movement."
 skill: true
 ---
 

--- a/docs/content/docs/custom-software/building-wasm.mdx
+++ b/docs/content/docs/custom-software/building-wasm.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Building Binaries"
-description: "Compile WASM command binaries for agentOS from source."
+description: "Compile command-line software to WebAssembly for agentOS VMs, package the resulting binaries, and verify they run in the guest environment."
 ---
 
 WASM command packages ship **compiled `.wasm` binaries** in their `bin/` that run inside the VM as guest commands. The binaries are build artifacts and are not checked into git, so to add or change a command you build it from source in the AgentOS repo.
@@ -61,4 +61,4 @@ Install a published package and pass it to `software`. Registry WASM packages ar
 
 <CodeSnippet file="examples/software/registry-usage.ts" />
 
-Meta-packages bundle a full set, e.g. `@agentos-software/common` (coreutils, sed, grep, gawk, findutils, diffutils, tar, gzip). Run the commands from the client; see [Processes & Shell](/agentos/docs/processes). Browse the full catalog on the [Registry](/registry), and see the package descriptor in [Software Definition](/agentos/docs/custom-software/definition). To ship your package to npm or use a local build, see [Publishing Packages](/agentos/docs/custom-software/publishing).
+Meta-packages bundle a full set, e.g. `@agentos-software/common` (coreutils, sed, grep, gawk, findutils, diffutils, tar, gzip). Run the commands from the client; see [Processes & Shell](/agentos/docs/processes/). Browse the full catalog on the [Registry](/agentos/registry/), and see the package descriptor in [Software Definition](/agentos/docs/custom-software/definition/). To ship your package to npm or use a local build, see [Publishing Packages](/agentos/docs/custom-software/publishing/).

--- a/docs/content/docs/custom-software/definition.mdx
+++ b/docs/content/docs/custom-software/definition.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Software Definition"
-description: "The software-package definition for custom commands and agents in an agentOS VM: a package is a packed .aospkg (or a package directory), declared with defineSoftware({ packagePath })."
+description: "Define custom agentOS software packages, provide packed or local package paths, and expose commands and coding-agent adapters inside VMs."
 ---
 
 **Software** is anything you install into a VM — **commands** (executables in a package's `bin/`) or an **agent** (a package that also exposes an ACP session).

--- a/docs/content/docs/custom-software/publishing.mdx
+++ b/docs/content/docs/custom-software/publishing.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Publishing Packages"
-description: "Build, publish, and consume agentOS packages — locally, from npm, or from your own repo."
+description: "Package, publish, and consume custom agentOS software through local paths, npm registries, or private repositories with pinned versions."
 ---
 
 agentOS packages — WASM command sets and packed JS agents alike — go through one lifecycle, owned by the **`@rivet-dev/agentos-toolchain`** CLI. This page covers the full flow: building a package, publishing it to npm, and wiring a consumer at either a published version or a local checkout.

--- a/docs/content/docs/debugging.mdx
+++ b/docs/content/docs/debugging.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Debugging"
-description: "Capture agent logs and runtime (sidecar) logs to diagnose sessions, tool calls, and crashes."
+description: "Diagnose agentOS sessions, tool calls, VM crashes, and runtime failures by collecting coding-agent logs, sidecar logs, and execution context."
 ---
 
 Before reaching for logs, open the [inspector](/agentos/docs/inspector): it shows the live transcript, pending permission requests (the most common reason an agent looks stuck), and the process tree.

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Introduction"
-description: "Run coding agents inside isolated VMs with full filesystem, process, and network control."
+description: "Run coding agents in isolated agentOS VMs with controlled filesystems, processes, networking, durable sessions, and Rivet Actor persistence."
 ---
 
 agentOS runs coding agents inside isolated VMs with full filesystem, process, and

--- a/docs/content/docs/inspector.mdx
+++ b/docs/content/docs/inspector.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Inspector"
-description: "Watch and drive a live VM from the Rivet dashboard: transcript, filesystem, and system tabs."
+description: "Inspect and control a live agentOS VM from the Rivet dashboard, including transcripts, files, processes, system data, and session actions."
 ---
 
 Every agentOS actor ships a set of tabs for the Rivet dashboard's actor inspector. Open a running VM and you can read the agent's transcript, send it prompts, answer permission requests, browse the filesystem, and watch its processes. Nothing to configure: the tabs register automatically when you use `agentOS()`.

--- a/docs/content/docs/javascript-compatibility.mdx
+++ b/docs/content/docs/javascript-compatibility.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Node.js Compatibility"
-description: "Node.js builtins available to JavaScript running inside AgentOS."
+description: "Review the Node.js built-in modules and compatibility guarantees available to JavaScript and TypeScript code running inside agentOS VMs."
 ---
 
 Guest JavaScript never touches the host Node.js runtime.

--- a/docs/content/docs/limitations.mdx
+++ b/docs/content/docs/limitations.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Limitations"
-description: "What the agentOS VM does not support, and how to work around it."
+description: "Understand current agentOS VM limitations, unsupported features, and recommended workarounds before choosing an execution architecture."
 skill: true
 ---
 
@@ -16,7 +16,7 @@ See [agentOS vs Sandbox](/agentos/docs/versus-sandbox) for a detailed comparison
 
 ### Software registry
 
-agentOS uses its own [software registry](/registry) of popular tools cross-compiled for the runtime. You cannot download and install arbitrary binaries (for example via `curl` or `apt`), and standard Linux package managers (`apt`, `yum`) are not available since agentOS runs a streamlined Linux environment rather than a full distribution. Native binaries that are not yet available in the registry (such as Go, Rust, or C++ toolchains) require a full [external sandbox](/agentos/docs/sandboxes).
+agentOS uses its own [software registry](/agentos/registry/) of popular tools cross-compiled for the runtime. You cannot download and install arbitrary binaries (for example via `curl` or `apt`), and standard Linux package managers (`apt`, `yum`) are not available since agentOS runs a streamlined Linux environment rather than a full distribution. Native binaries that are not yet available in the registry (such as Go, Rust, or C++ toolchains) require a full [external sandbox](/agentos/docs/sandboxes/).
 
 See [Software](/agentos/docs/software) for how to install and configure available packages.
 

--- a/docs/content/docs/models-and-credentials.mdx
+++ b/docs/content/docs/models-and-credentials.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Models & Credentials"
-description: "Choose agent models and pass provider credentials to sessions securely."
+description: "Choose coding-agent models, pass provider credentials securely to agentOS sessions, and control which secrets are available to each adapter."
 skill: true
 ---
 

--- a/docs/content/docs/multiplayer.mdx
+++ b/docs/content/docs/multiplayer.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Multiplayer"
-description: "Connect multiple clients to the same agentOS actor for collaborative agent workflows."
+description: "Connect multiple clients to one agentOS actor for collaborative coding-agent sessions with shared transcripts, state, and realtime updates."
 skill: true
 ---
 

--- a/docs/content/docs/networking.mdx
+++ b/docs/content/docs/networking.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Networking & Previews"
-description: "Proxy HTTP requests into agentOS VMs and create shareable preview URLs."
+description: "Proxy HTTP traffic into agentOS VMs, configure network access, and create shareable preview URLs for services started by coding agents."
 skill: true
 ---
 

--- a/docs/content/docs/performance.mdx
+++ b/docs/content/docs/performance.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Performance"
-description: "AgentOS latency, memory, cost, and benchmark methodology."
+description: "Measure and optimize agentOS VM startup latency, memory use, execution cost, throughput, and benchmarks with reproducible methodology."
 skill: true
 ---
 

--- a/docs/content/docs/permissions.mdx
+++ b/docs/content/docs/permissions.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Permissions"
-description: "The per-scope kernel permission policy that gates every guest syscall in the sandbox."
+description: "Define scoped agentOS kernel permissions that authorize guest filesystem, process, and network operations for each VM and session."
 skill: true
 ---
 

--- a/docs/content/docs/persistence.mdx
+++ b/docs/content/docs/persistence.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Persistence & Sleep"
-description: "How agentOS persists files and manages sleep/wake cycles."
+description: "Understand how agentOS persists VM files, durable session catalogs, and completed history across actor sleep, wake, restart, and worker movement."
 skill: true
 ---
 

--- a/docs/content/docs/processes.mdx
+++ b/docs/content/docs/processes.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Processes & Shell"
-description: "Execute commands, spawn long-running processes, and open interactive shells in agentOS VMs."
+description: "Run commands, start long-lived processes, and open interactive shells inside agentOS VMs with controlled environment and lifecycle management."
 skill: true
 ---
 

--- a/docs/content/docs/python.mdx
+++ b/docs/content/docs/python.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Python"
-description: "Execute Python source, files, modules, and package workflows in agentOS."
+seoTitle: "Run Python Code in agentOS VMs"
+description: "Execute Python source, files, modules, and package workflows in agentOS VMs with controlled filesystem, environment, output, and lifecycle."
 skill: true
 ---
 

--- a/docs/content/docs/quickstart.mdx
+++ b/docs/content/docs/quickstart.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Quickstart"
-description: "Set up an agentOS actor, create a session, and run your first coding agent."
+description: "Create an agentOS actor, launch an isolated VM session, run a coding agent, send a prompt, and inspect the durable result."
 skill: true
 ---
 

--- a/docs/content/docs/security-model.mdx
+++ b/docs/content/docs/security-model.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Security Model"
-description: "Trust boundaries, isolation guarantees, and the agentOS threat model."
+description: "Understand agentOS trust boundaries, VM isolation, permission enforcement, guest threats, and the responsibilities of trusted host components."
 skill: true
 ---
 

--- a/docs/content/docs/sessions.mdx
+++ b/docs/content/docs/sessions.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Sessions"
-description: "Open durable ACP sessions, prompt them, read history, and restore adapters."
+description: "Open durable Agent Client Protocol sessions in agentOS, send prompts, stream events, read transcripts, and restore coding-agent adapters."
 skill: true
 ---
 

--- a/docs/content/docs/software.mdx
+++ b/docs/content/docs/software.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Software"
-description: "Install software packages and configure the commands available inside agentOS."
+description: "Install and configure agentOS software packages to control the commands, tools, and coding-agent adapters available inside each VM."
 skill: true
 ---
 
@@ -12,7 +12,7 @@ agentOS ships with a common set of POSIX utilities (coreutils, sed, grep, gawk, 
 npm install @rivet-dev/agentos @agentos-software/pi
 ```
 
-Add packages like `@agentos-software/ripgrep` or `@agentos-software/jq` for anything beyond the default utilities. Browse the full catalog on the [Registry](/registry).
+Add packages like `@agentos-software/ripgrep` or `@agentos-software/jq` for anything beyond the default utilities. Browse the full catalog on the [Registry](/agentos/registry/).
 
 ## Usage
 
@@ -26,7 +26,7 @@ Import the software packages you want, list them in the `software` array on the 
 
 ## Available Packages
 
-Browse all available software packages on the [Registry](/registry).
+Browse all available software packages on the [Registry](/agentos/registry/).
 
 ## Custom Software
 

--- a/docs/content/docs/system-prompt.mdx
+++ b/docs/content/docs/system-prompt.mdx
@@ -1,6 +1,6 @@
 ---
 title: "System Prompt"
-description: "How agentOS injects context into agent sessions."
+description: "Configure the context agentOS injects into coding-agent sessions, including environment details, available tools, and workspace guidance."
 skill: true
 ---
 

--- a/docs/content/docs/versus-sandbox.mdx
+++ b/docs/content/docs/versus-sandbox.mdx
@@ -1,6 +1,6 @@
 ---
 title: "agentOS vs Sandbox"
-description: "When to use the lightweight agentOS VM, a full sandbox, or both together."
+description: "Choose between lightweight agentOS VMs, full external sandboxes, or a combined architecture based on isolation, compatibility, and workload needs."
 skill: true
 ---
 

--- a/docs/content/docs/workflows.mdx
+++ b/docs/content/docs/workflows.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Workflows & Graphs"
-description: "Orchestrate multi-step agent tasks with durable workflows."
+description: "Orchestrate multi-step coding-agent tasks with durable agentOS workflows, graph dependencies, retries, state, and resumable execution."
 skill: true
 ---
 
@@ -34,4 +34,4 @@ Output of one agent session feeds into the next. Each session is created and com
 - Pass data between steps via the filesystem or step return values, not session state.
 - Keep `state` changes and other actor-local side effects inside `ctx.step()` callbacks; use non-step workflow code only for orchestration.
 - Reach the agentOS VM, a separate actor, from inside a step with `ctx.client()`.
-- See [Workflows](https://rivet.dev/docs/actors/workflows) for the full workflow API reference including timers, joins, and races.
+- See [Workflows](/workflows/docs/) for the full workflow API reference including timers, joins, and races.

--- a/docs/content/integrations/rivet.mdx
+++ b/docs/content/integrations/rivet.mdx
@@ -6,7 +6,7 @@ skill: true
 
 import DeployTargets from '@/components/docs/DeployTargets.astro';
 
-Rivet is agentOS's native framework. The `agentOS()` function returns an ordinary [Rivet Actor](https://rivet.dev/docs/actors), so each agentOS VM is a directly addressable actor with its own durable filesystem, state, and session history—no adapter layer required.
+Rivet is agentOS's native framework. The `agentOS()` function returns an ordinary [Rivet Actor](/actors/docs/), so each agentOS VM is a directly addressable actor with its own durable filesystem, state, and session history—no adapter layer required.
 
 [View the complete example →](https://github.com/rivet-dev/agentos/tree/main/examples/quickstart-app)
 
@@ -80,4 +80,4 @@ Deploy to one of the supported platforms:
 
 ## Learn more
 
-See the [agentOS quickstart](/agentos/docs/quickstart) for VM configuration and the [Rivet Actor documentation](https://rivet.dev/docs/actors) for state, actions, events, queues, workflows, and deployment.
+See the [agentOS quickstart](/agentos/docs/quickstart/) for VM configuration and the [Rivet Actor documentation](/actors/docs/) for state, actions, events, queues, workflows, and deployment.

--- a/docs/content/integrations/vercel-eve.mdx
+++ b/docs/content/integrations/vercel-eve.mdx
@@ -139,7 +139,7 @@ See the `agentOS()` [configuration reference](/agentos/docs/core#configuration-r
 
 Rivet World stores Eve workflow runs in Rivet Actors so they resume instead of restarting.
 
-[Read the Rivet World documentation →](https://rivet.dev/docs/integrations/vercel-workflows)
+[Read the Rivet Workflows integration documentation →](/actors/integrations/workflow-sdk/)
 
 ## Advanced
 

--- a/docs/public/images/architecture/javascript-executor-readiness-state-dark.svg
+++ b/docs/public/images/architecture/javascript-executor-readiness-state-dark.svg
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="1860" height="1540" viewBox="0 0 1860 1540" role="img" aria-labelledby="title desc">
+  <title id="title">AgentOS coalesced readiness state machine</title>
+  <desc id="desc">Dark-mode state machine demonstrating flags, per-capability revisions, per-VM wake epochs, acknowledgement races, and JavaScript backpressure.</desc>
+  <defs>
+    <marker id="arrA" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto"><path d="M0 0L10 5L0 10Z" fill="#f6bd60"/></marker>
+    <marker id="arrV" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto"><path d="M0 0L10 5L0 10Z" fill="#b794f4"/></marker>
+    <marker id="arrG" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto"><path d="M0 0L10 5L0 10Z" fill="#4ade80"/></marker>
+    <style>
+      .bg{fill:#090d14}.panel{fill:#101722;stroke:#334155;stroke-width:2}.state{fill:#2c2516;stroke:#f6bd60;stroke-width:2}.v8{fill:#2a1f3d;stroke:#b794f4;stroke-width:2}.data{fill:#102a37;stroke:#48cae4;stroke-width:2}.back{fill:#142d25;stroke:#4ade80;stroke-width:2}.title{font:700 34px Inter,system-ui,sans-serif;fill:#f8fafc}.subtitle{font:17px Inter,system-ui,sans-serif;fill:#94a3b8}.h1{font:700 23px Inter,system-ui,sans-serif;fill:#f8fafc}.h2{font:700 18px Inter,system-ui,sans-serif;fill:#e2e8f0}.body{font:15px Inter,system-ui,sans-serif;fill:#cbd5e1}.small{font:13px Inter,system-ui,sans-serif;fill:#94a3b8}.mono{font:14px "SFMono-Regular",Consolas,monospace;fill:#dbeafe}.amber{fill:none;stroke:#f6bd60;stroke-width:3;marker-end:url(#arrA)}.violet{fill:none;stroke:#b794f4;stroke-width:3;marker-end:url(#arrV)}.green{fill:none;stroke:#4ade80;stroke-width:3;marker-end:url(#arrG)}.dash{stroke-dasharray:8 7}.center{text-anchor:middle}.step{fill:#2563eb}.stepText{font:700 13px Inter,system-ui,sans-serif;fill:#fff;text-anchor:middle;dominant-baseline:middle}.code{fill:#111827;stroke:#52657f;stroke-width:1.5}.warning{fill:#321f24;stroke:#fb7185;stroke-width:1.5}.good{fill:#142d25;stroke:#4ade80;stroke-width:1.5}
+    </style>
+  </defs>
+  <rect class="bg" width="1860" height="1540"/>
+  <text class="title" x="55" y="58">4 · Coalescing — revisions are counters, not queued messages</text>
+  <text class="subtitle" x="55" y="91">Example for capability 42. One per-handle map entry survives races; one per-VM epoch identifies the currently outstanding doorbell.</text>
+
+  <rect class="panel" x="40" y="125" width="1780" height="920" rx="20"/>
+  <text class="h1" x="70" y="168">Timeline: three readiness publications become at most two wakes</text>
+
+  <!-- timeline states -->
+  <rect class="state" x="75" y="220" width="285" height="235" rx="15"/>
+  <circle class="step" cx="105" cy="250" r="15"/><text class="stepText" x="105" y="250">0</text>
+  <text class="h2" x="130" y="256">Idle</text>
+  <text class="mono" x="100" y="300">queue = []</text>
+  <text class="mono" x="100" y="330">flags = ∅</text>
+  <text class="mono" x="100" y="360">revision = 7</text>
+  <text class="mono" x="100" y="390">wake = Idle</text>
+  <text class="small" x="100" y="425">No task or thread is spinning.</text>
+
+  <rect class="state" x="410" y="220" width="315" height="235" rx="15"/>
+  <circle class="step" cx="440" cy="250" r="15"/><text class="stepText" x="440" y="250">1</text>
+  <text class="h2" x="465" y="256">First Data event</text>
+  <text class="mono" x="435" y="300">queue = [chunk A]</text>
+  <text class="mono" x="435" y="330">flags = READABLE</text>
+  <text class="mono" x="435" y="360">revision = 8</text>
+  <text class="mono" x="435" y="390">wake = Outstanding(11)</text>
+  <text class="small" x="435" y="425">Enqueue ReadyWake(epoch 11).</text>
+
+  <rect class="state" x="775" y="220" width="315" height="235" rx="15"/>
+  <circle class="step" cx="805" cy="250" r="15"/><text class="stepText" x="805" y="250">2</text>
+  <text class="h2" x="830" y="256">More Data before drain</text>
+  <text class="mono" x="800" y="300">queue = [chunk A, chunk B]</text>
+  <text class="mono" x="800" y="330">flags = READABLE</text>
+  <text class="mono" x="800" y="360">revision = 9</text>
+  <text class="mono" x="800" y="390">wake = Outstanding(11)</text>
+  <text class="small" x="800" y="425">No second wake: already outstanding.</text>
+
+  <rect class="v8" x="1140" y="220" width="315" height="235" rx="15"/>
+  <circle class="step" cx="1170" cy="250" r="15"/><text class="stepText" x="1170" y="250">3</text>
+  <text class="h2" x="1195" y="256">V8 takes batch</text>
+  <text class="mono" x="1165" y="300">epoch = 11</text>
+  <text class="mono" x="1165" y="330">cap = 42</text>
+  <text class="mono" x="1165" y="360">flags = READABLE</text>
+  <text class="mono" x="1165" y="390">observedRevision = 9</text>
+  <text class="small" x="1165" y="425">This is a snapshot, not removal.</text>
+
+  <rect class="state" x="1505" y="220" width="270" height="235" rx="15"/>
+  <circle class="step" cx="1535" cy="250" r="15"/><text class="stepText" x="1535" y="250">4</text>
+  <text class="h2" x="1560" y="256">Race: chunk C</text>
+  <text class="mono" x="1530" y="300">queue += chunk C</text>
+  <text class="mono" x="1530" y="330">flags = READABLE</text>
+  <text class="mono" x="1530" y="360">revision = 10</text>
+  <text class="mono" x="1530" y="390">wake = Outstanding(11)</text>
+  <text class="small" x="1530" y="425">Still no extra wake yet.</text>
+
+  <path class="amber" d="M360 337H410"/>
+  <path class="amber" d="M725 337H775"/>
+  <path class="violet" d="M1090 337H1140"/>
+  <path class="amber" d="M1455 337H1505"/>
+
+  <!-- acknowledgement -->
+  <rect class="v8" x="165" y="535" width="420" height="190" rx="15"/>
+  <circle class="step" cx="195" cy="566" r="15"/><text class="stepText" x="195" y="566">5</text>
+  <text class="h2" x="220" y="572">V8 acknowledges what it observed</text>
+  <text class="mono" x="195" y="616">complete_wake(epoch=11, observedRevision=9)</text>
+  <text class="body" x="195" y="654">Current revision is 10, so flags are not cleared.</text>
+  <text class="small" x="195" y="688">An old acknowledgement cannot erase newer work.</text>
+
+  <rect class="state" x="720" y="535" width="420" height="190" rx="15"/>
+  <circle class="step" cx="750" cy="566" r="15"/><text class="stepText" x="750" y="566">6</text>
+  <text class="h2" x="775" y="572">Broker atomically rearms</text>
+  <text class="mono" x="750" y="616">wake: Outstanding(11) → Idle</text>
+  <text class="mono" x="750" y="646">work remains → Outstanding(12)</text>
+  <text class="body" x="750" y="680">Exactly one replacement wake is enqueued.</text>
+
+  <rect class="good" x="1275" y="535" width="420" height="190" rx="15"/>
+  <circle class="step" cx="1305" cy="566" r="15"/><text class="stepText" x="1305" y="566">7</text>
+  <text class="h2" x="1330" y="572">Next drain catches up</text>
+  <text class="mono" x="1305" y="616">batch(epoch=12, revision=10)</text>
+  <text class="mono" x="1305" y="646">ack revision=10 → clear READABLE</text>
+  <text class="body" x="1305" y="680">If no other work exists, wake returns to Idle.</text>
+
+  <path class="violet" d="M585 630H720"/>
+  <path class="amber" d="M1140 630H1275"/>
+
+  <rect class="code" x="100" y="790" width="760" height="200" rx="14"/>
+  <text class="h2" x="130" y="827">What is bounded?</text>
+  <text class="body" x="130" y="864">• ReadyState has at most one entry per admitted capability.</text>
+  <text class="body" x="130" y="897">• The wake mailbox has capacity one and state permits one queued/in-flight epoch.</text>
+  <text class="body" x="130" y="930">• The socket completion queue is bounded by event count and charged bytes.</text>
+  <text class="body" x="130" y="963">• ready_batch copies at most the configured work quantum.</text>
+
+  <rect class="warning" x="955" y="790" width="800" height="200" rx="14"/>
+  <text class="h2" x="985" y="827">What is not a queue?</text>
+  <text class="body" x="985" y="864">• Revision 8 → 9 → 10 is one integer field being updated, not three queued revisions.</text>
+  <text class="body" x="985" y="897">• READABLE is one level bit, not one event per packet or byte chunk.</text>
+  <text class="body" x="985" y="930">• Epoch 11 identifies one wake cycle; it does not enumerate the socket events.</text>
+  <text class="body" x="985" y="963">• The wake never owns payload bytes, so wake coalescing cannot lose data.</text>
+
+  <!-- backpressure lower panel -->
+  <rect class="panel" x="40" y="1090" width="1780" height="400" rx="20"/>
+  <text class="h1" x="70" y="1133">Backpressure state: JavaScript controls whether the Tokio reader is allowed to read again</text>
+  <rect class="v8" x="85" y="1190" width="360" height="205" rx="14"/>
+  <text class="h2" x="115" y="1223">Guest Readable buffer</text>
+  <text class="h2" x="115" y="1246">reaches its high-water mark</text>
+  <text class="mono" x="115" y="1280">Readable.push(bytes) === false</text>
+  <text class="body" x="115" y="1312">applicationReadDemand = false</text>
+  <text class="body" x="115" y="1342">bridge: SetReadInterest(false)</text>
+  <text class="small" x="115" y="1370">This is stream backpressure, not unref().</text>
+
+  <rect class="state" x="555" y="1190" width="360" height="205" rx="14"/>
+  <text class="h2" x="585" y="1225">Broker + socket capability pause</text>
+  <text class="body" x="585" y="1263">clear/suppress READABLE delivery</text>
+  <text class="body" x="585" y="1296">applicationReadInterest = false</text>
+  <text class="body" x="585" y="1329">reader waits on Notify</text>
+  <text class="small" x="585" y="1370">No repeated level-ready spin or wake storm.</text>
+
+  <rect class="data" x="1025" y="1190" width="330" height="205" rx="14"/>
+  <text class="h2" x="1055" y="1225">Where bytes wait</text>
+  <text class="body" x="1055" y="1263">bounded already-read completion state</text>
+  <text class="body" x="1055" y="1296">plus OS receive buffer</text>
+  <text class="body" x="1055" y="1329">plus sender-side TCP flow control</text>
+  <text class="small" x="1055" y="1370">No additional readiness messages accumulate.</text>
+
+  <rect class="back" x="1465" y="1190" width="310" height="205" rx="14"/>
+  <text class="h2" x="1495" y="1225">When JS needs more</text>
+  <text class="mono" x="1495" y="1263">_read()</text>
+  <text class="body" x="1495" y="1296">SetReadInterest(true)</text>
+  <text class="body" x="1495" y="1329">wake reader + republish if known</text>
+  <text class="small" x="1495" y="1370">The bounded cycle begins again.</text>
+
+  <path class="green" d="M445 1290H555"/>
+  <path class="green" d="M915 1290H1025"/>
+  <path class="green" d="M1355 1290H1465"/>
+  <path class="green dash" d="M1620 1395C1620 1465 270 1465 270 1395"/>
+</svg>

--- a/docs/public/images/architecture/javascript-executor-wakeup-sequence-dark.svg
+++ b/docs/public/images/architecture/javascript-executor-wakeup-sequence-dark.svg
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="1900" height="1820" viewBox="0 0 1900 1820" role="img" aria-labelledby="title desc">
+  <title id="title">AgentOS socket readiness to V8 sequence</title>
+  <desc id="desc">Dark-mode sequence diagram showing how a Tokio socket task stores data, publishes readiness, wakes the separate V8 executor, and causes JavaScript to drain the data.</desc>
+  <defs>
+    <marker id="arrowCyan" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto"><path d="M0 0L10 5L0 10Z" fill="#48cae4"/></marker>
+    <marker id="arrowAmber" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto"><path d="M0 0L10 5L0 10Z" fill="#f6bd60"/></marker>
+    <marker id="arrowViolet" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto"><path d="M0 0L10 5L0 10Z" fill="#b794f4"/></marker>
+    <marker id="arrowGreen" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto"><path d="M0 0L10 5L0 10Z" fill="#4ade80"/></marker>
+    <style>
+      .bg{fill:#090d14}.actor{fill:#151f2e;stroke:#42526b;stroke-width:2}.actorTokio{fill:#102a37;stroke:#48cae4;stroke-width:2}.actorState{fill:#2c2516;stroke:#f6bd60;stroke-width:2}.actorV8{fill:#2a1f3d;stroke:#b794f4;stroke-width:2}.title{font:700 34px Inter,system-ui,sans-serif;fill:#f8fafc}.subtitle{font:17px Inter,system-ui,sans-serif;fill:#94a3b8}.h2{font:700 17px Inter,system-ui,sans-serif;fill:#e2e8f0}.body{font:15px Inter,system-ui,sans-serif;fill:#cbd5e1}.small{font:13px Inter,system-ui,sans-serif;fill:#94a3b8}.mono{font:14px "SFMono-Regular",Consolas,monospace;fill:#dbeafe}.life{stroke:#475569;stroke-width:2;stroke-dasharray:7 8}.cyan{stroke:#48cae4;stroke-width:3;fill:none;marker-end:url(#arrowCyan)}.amber{stroke:#f6bd60;stroke-width:3;fill:none;marker-end:url(#arrowAmber)}.violet{stroke:#b794f4;stroke-width:3;fill:none;marker-end:url(#arrowViolet)}.green{stroke:#4ade80;stroke-width:3;fill:none;marker-end:url(#arrowGreen)}.return{stroke-dasharray:8 6}.note{fill:#111827;stroke:#52657f;stroke-width:1.5}.danger{fill:#321f24;stroke:#fb7185;stroke-width:1.5}.step{fill:#2563eb}.stepText{font:700 13px Inter,system-ui,sans-serif;fill:#fff;text-anchor:middle;dominant-baseline:middle}.center{text-anchor:middle}.band{fill:#0d1522;stroke:#23324a;stroke-width:1}
+    </style>
+  </defs>
+  <rect class="bg" width="1900" height="1820"/>
+  <text class="title" x="55" y="58">2 · One TCP read — exact wake-up and call-into-V8 sequence</text>
+  <text class="subtitle" x="55" y="91">The wake is only a doorbell. The actual bytes take a separate path and are fetched by JavaScript after V8 is awake.</text>
+
+  <!-- Actor headers -->
+  <rect class="actor" x="35" y="125" width="210" height="88" rx="13"/>
+  <text class="h2 center" x="140" y="158">OS kernel</text><text class="small center" x="140" y="184">TCP + epoll</text>
+  <rect class="actorTokio" x="285" y="125" width="260" height="88" rx="13"/>
+  <text class="h2 center" x="415" y="158">Tokio socket task</text><text class="small center" x="415" y="184">shared runtime worker</text>
+  <rect class="actorState" x="585" y="125" width="250" height="88" rx="13"/>
+  <text class="h2 center" x="710" y="158">Completion queue</text><text class="small center" x="710" y="184">bounded, contains bytes</text>
+  <rect class="actorState" x="875" y="125" width="250" height="88" rx="13"/>
+  <text class="h2 center" x="1000" y="158">ReadyState broker</text><text class="small center" x="1000" y="184">flags + revisions</text>
+  <rect class="actorV8" x="1165" y="125" width="290" height="88" rx="13"/>
+  <text class="h2 center" x="1310" y="158">V8 executor thread</text><text class="small center" x="1310" y="184">owns isolate + selector</text>
+  <rect class="actorV8" x="1495" y="125" width="360" height="88" rx="13"/>
+  <text class="h2 center" x="1675" y="158">Guest JS NetSocket</text><text class="small center" x="1675" y="184">readiness target + Duplex</text>
+
+  <line class="life" x1="140" y1="213" x2="140" y2="1720"/>
+  <line class="life" x1="415" y1="213" x2="415" y2="1720"/>
+  <line class="life" x1="710" y1="213" x2="710" y2="1720"/>
+  <line class="life" x1="1000" y1="213" x2="1000" y2="1720"/>
+  <line class="life" x1="1310" y1="213" x2="1310" y2="1720"/>
+  <line class="life" x1="1675" y1="213" x2="1675" y2="1720"/>
+
+  <rect class="band" x="20" y="245" width="1860" height="285" rx="12"/>
+  <text class="h2" x="45" y="278">A. Tokio discovers work and stores it</text>
+  <circle class="step" cx="265" cy="325" r="15"/><text class="stepText" x="265" y="325">1</text>
+  <path class="cyan" d="M140 325H415"/>
+  <text class="body" x="175" y="312">fd readable → Tokio Waker schedules socket future</text>
+  <circle class="step" cx="265" cy="395" r="15"/><text class="stepText" x="265" y="395">2</text>
+  <path class="cyan" d="M415 395H140"/>
+  <text class="body" x="180" y="382">bounded try_read() turn</text>
+  <path class="cyan return" d="M140 435H415"/>
+  <text class="mono" x="175" y="424">bytes: [48 65 6c 6c 6f]</text>
+  <circle class="step" cx="565" cy="480" r="15"/><text class="stepText" x="565" y="480">3</text>
+  <path class="cyan" d="M415 480H710"/>
+  <text class="body" x="450" y="467">send Data(bytes, accounting reservation)</text>
+  <text class="small" x="745" y="485">If full, this task stops reading; the bytes remain in the kernel.</text>
+
+  <rect class="band" x="20" y="555" width="1860" height="350" rx="12"/>
+  <text class="h2" x="45" y="588">B. The same publisher rings one coalesced doorbell</text>
+  <circle class="step" cx="705" cy="640" r="15"/><text class="stepText" x="705" y="640">4</text>
+  <path class="amber" d="M415 640H1000"/>
+  <text class="mono" x="500" y="627">publish(cap=42, gen=3, READABLE)</text>
+  <rect class="note" x="860" y="675" width="430" height="95" rx="10"/>
+  <text class="body" x="885" y="705">ReadyState[42].flags |= READABLE</text>
+  <text class="body" x="885" y="733">ReadyState[42].revision += 1</text>
+  <text class="small" x="885" y="758">Repeated publications overwrite/merge this entry.</text>
+  <circle class="step" cx="1150" cy="810" r="15"/><text class="stepText" x="1150" y="810">5</text>
+  <path class="amber" d="M1000 810H1310"/>
+  <text class="mono" x="1030" y="797">ReadyWake { generation, epoch }</text>
+  <text class="small" x="1030" y="842">Internally: Tokio MPSC[1] staging → immediate crossbeam[1] transfer.</text>
+  <text class="small" x="1030" y="864">No bytes, socket event, packet count, or revision list is in the wake.</text>
+
+  <rect class="band" x="20" y="930" width="1860" height="405" rx="12"/>
+  <text class="h2" x="45" y="963">C. The V8 thread notices the wake and enters JavaScript itself</text>
+  <rect class="actorV8" x="1180" y="990" width="260" height="67" rx="10"/>
+  <text class="body center" x="1310" y="1018">crossbeam Select unblocks</text>
+  <text class="small center" x="1310" y="1041">Tokio did not enter V8</text>
+  <circle class="step" cx="1150" cy="1095" r="15"/><text class="stepText" x="1150" y="1095">6</text>
+  <path class="amber" d="M1310 1095H1000"/>
+  <text class="mono" x="1040" y="1082">take_batch(epoch)</text>
+  <path class="amber return" d="M1000 1140H1310"/>
+  <text class="mono" x="1025" y="1128">[(cap=42, gen=3, flags=R, revision=9)]</text>
+  <circle class="step" cx="1490" cy="1195" r="15"/><text class="stepText" x="1490" y="1195">7</text>
+  <path class="violet" d="M1310 1195H1675"/>
+  <text class="mono" x="1340" y="1182">V8 Function::call(_agentOSReadyDispatch, 42, 3, R)</text>
+  <rect class="note" x="1495" y="1225" width="360" height="82" rx="10"/>
+  <text class="body" x="1520" y="1254">JS Map lookup → wakeSocketBridgeReads()</text>
+  <text class="small" x="1520" y="1282">Queues a JS microtask; still on the V8 thread.</text>
+
+  <rect class="band" x="20" y="1360" width="1860" height="365" rx="12"/>
+  <text class="h2" x="45" y="1393">D. JavaScript fetches bytes over a call-specific bridge response</text>
+  <circle class="step" cx="1490" cy="1445" r="15"/><text class="stepText" x="1490" y="1445">8</text>
+  <path class="green" d="M1675 1445C1490 1445 1490 1505 710 1505"/>
+  <text class="mono" x="1010" y="1433">_netSocketReadRaw.applySync(socketId)</text>
+  <text class="small" x="1030" y="1460">V8 executor blocks only itself while the registered call waiter settles.</text>
+  <path class="green return" d="M710 1545C1040 1545 1390 1580 1675 1580"/>
+  <text class="mono" x="1010" y="1564">dequeue Data → direct response → actual bytes</text>
+  <circle class="step" cx="1490" cy="1610" r="15"/><text class="stepText" x="1490" y="1610">9</text>
+  <text class="body" x="1518" y="1616">Readable.push(bytes)</text>
+  <circle class="step" cx="1150" cy="1685" r="15"/><text class="stepText" x="1150" y="1685">10</text>
+  <path class="amber" d="M1310 1685H1000"/>
+  <text class="mono" x="1030" y="1672">complete_batch(epoch, observed revisions)</text>
+  <text class="small" x="1030" y="1708">Clears only unchanged observations; newer revisions cause a replacement wake.</text>
+
+  <rect class="danger" x="45" y="1748" width="1810" height="48" rx="10"/>
+  <text class="body center" x="950" y="1778">Important: the readiness path wakes V8; the bridge read path transports bytes. They are separate so millions of readiness signals cannot become millions of queued payload messages.</text>
+</svg>

--- a/docs/sidebar.json
+++ b/docs/sidebar.json
@@ -106,6 +106,10 @@
 					"icon": "faNodeJs"
 				},
 				{
+					"title": "Node.js Compatibility",
+					"href": "/agentos/docs/javascript-compatibility"
+				},
+				{
 					"title": "Python",
 					"href": "/agentos/docs/python",
 					"icon": "faPython"


### PR DESCRIPTION
## Summary\n\n- improve current agentOS documentation SEO titles and descriptions\n- add JavaScript compatibility to the Execution sidebar after Node.js\n- restore the two architecture SVG assets from their pre-migration blobs\n- update current documentation links to canonical destinations\n\n## Validation\n\n- consumed these sources through the website docs assembler\n- production website build, sitemap validation, and built SEO crawl pass\n- restored SVGs match their historical blobs exactly\n- git diff --check passes