### PR TITLE
fix(core,sidecar): route sidecar events by VM ownership, not execution id alone

### DIFF
--- a/crates/native-sidecar/src/language_execution.rs
+++ b/crates/native-sidecar/src/language_execution.rs
@@ -34,6 +34,10 @@ const INLINE_FILE_PATH_ENV: &str = "AGENTOS_INLINE_FILE_PATH";
 const USE_BUNDLED_TYPESCRIPT_ENV: &str = "AGENTOS_USE_BUNDLED_TYPESCRIPT";
 const SEMANTIC_RESULT_PATH_PREFIX: &str = "/tmp/.agentos-semantic-result-";
 
+/// Monotonic suffix for minted public execution ids. Process-wide so ids stay
+/// unique across every VM this sidecar hosts, not merely within one VM.
+static NEXT_PUBLIC_EXECUTION_ID: AtomicU64 = AtomicU64::new(1);
+
 #[derive(Debug)]
 struct LoweredOperation {
     identity: ExecutionIdentityOptions,
@@ -1076,9 +1080,15 @@ where
                         execution_id
                     }
                     None => loop {
-                        vm.next_public_execution_id = vm.next_public_execution_id.saturating_add(1);
-                        let candidate =
-                            format!("operation-{now:x}-{:x}", vm.next_public_execution_id);
+                        // Process-wide, not per-VM. One sidecar process fans out to
+                        // many VMs whose events reach the host over a single shared
+                        // client that routes execution events by id alone, so a
+                        // per-VM counter makes K VMs mint the identical
+                        // `operation-{ms}-1` in the same millisecond and cross-talk.
+                        let candidate = format!(
+                            "operation-{now:x}-{:x}",
+                            NEXT_PUBLIC_EXECUTION_ID.fetch_add(1, Ordering::Relaxed)
+                        );
                         if !vm.executions.contains_key(&candidate) {
                             break candidate;
                         }

--- a/crates/native-sidecar/src/state.rs
+++ b/crates/native-sidecar/src/state.rs
@@ -880,7 +880,6 @@ pub(crate) struct VmState {
     /// Process IDs remain internal routing details in `execution_processes`.
     pub(crate) executions: BTreeMap<String, ManagedLanguageExecution>,
     pub(crate) execution_processes: BTreeMap<String, String>,
-    pub(crate) next_public_execution_id: u64,
     pub(crate) execution_retention_wake_deadline_ms: Option<u64>,
     pub(crate) execution_retention_wake_task: Option<tokio::task::JoinHandle<()>>,
     /// The VM filesystem is shared across executions, so package-manager

--- a/crates/native-sidecar/src/vm.rs
+++ b/crates/native-sidecar/src/vm.rs
@@ -550,7 +550,6 @@ where
                 next_vm_fetch_stream_id: 0,
                 executions: BTreeMap::new(),
                 execution_processes: BTreeMap::new(),
-                next_public_execution_id: 0,
                 execution_retention_wake_deadline_ms: None,
                 execution_retention_wake_task: None,
                 package_mutation_execution_id: None,

--- a/packages/core/src/agent-os.ts
+++ b/packages/core/src/agent-os.ts
@@ -6007,6 +6007,19 @@ export class AgentOs {
 			? T
 			: never,
 	): void {
+		// Every AgentOs sharing a sidecar handle listens on the SAME native
+		// process, so this callback sees every tenant VM's events. Execution ids
+		// are only unique within a VM, so dispatching on the id alone leaks
+		// another VM's stdout/exit into this instance. Drop foreign vm-scoped
+		// events here — before the mappers, which discard `ownership` — so every
+		// downstream id-keyed lookup below is automatically VM-local. Session-
+		// and connection-scoped events are not VM-specific and pass through.
+		if (
+			event.ownership.scope === "vm" &&
+			event.ownership.vm_id !== this._sidecarVm.vmId
+		) {
+			return;
+		}
 		if (event.payload.type === "execution_output") {
 			const output = mapExecutionOutputEvent(event.payload.event);
 			const pid = this._languageProcessIds.get(output.executionId);

--- a/packages/core/tests/cross-vm-execution-event-isolation.test.ts
+++ b/packages/core/tests/cross-vm-execution-event-isolation.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from "vitest";
+import { AgentOs } from "../src/index.js";
+
+// odw-0a6. Every AgentOs created from one sidecar handle listens on the SAME
+// native process, and execution ids are only unique inside a VM (they used to
+// be minted from a per-VM counter, so K VMs fanning out minted the identical id
+// in the same millisecond). Dispatching on the id alone therefore delivered
+// VM B's stdout and exit into VM A. `_handleSidecarEvent` must drop foreign
+// vm-scoped frames BEFORE the mappers run, since the mappers discard
+// `ownership` entirely.
+//
+// Built on the prototype rather than `AgentOs.create()`: the guard is pure
+// routing over the instance's own maps, and a real VM would drag in the whole
+// guest-software toolchain for nothing.
+const OWN_VM_ID = "vm-A";
+const FOREIGN_VM_ID = "vm-B";
+const COLLIDING_EXECUTION_ID = "operation-1-1";
+
+function ownership(vmId: string) {
+	return {
+		scope: "vm" as const,
+		connection_id: "conn-1",
+		session_id: "session-1",
+		vm_id: vmId,
+	};
+}
+
+function outputFrame(vmId: string) {
+	return {
+		ownership: ownership(vmId),
+		payload: {
+			type: "execution_output" as const,
+			event: {
+				executionId: COLLIDING_EXECUTION_ID,
+				generation: 1n,
+				processId: null,
+				sequence: 0n,
+				channel: "Stdout",
+				chunk: new TextEncoder().encode("secret").buffer,
+				timestampMs: 0n,
+			},
+		},
+	};
+}
+
+function completedFrame(vmId: string) {
+	return {
+		ownership: ownership(vmId),
+		payload: {
+			type: "execution_completed" as const,
+			event: {
+				executionId: COLLIDING_EXECUTION_ID,
+				generation: 1n,
+				outcome: "Succeeded",
+				exitCode: 0,
+				error: null,
+			},
+		},
+	};
+}
+
+interface EventRouterProbe {
+	_sidecarVm: { vmId: string };
+	_languageProcessIds: Map<string, number>;
+	_languageProcesses: Map<number, unknown>;
+	_executionOutputHandlers: Map<string, Set<(event: unknown) => void>>;
+	_executionCompletedHandlers: Map<string, Set<(event: unknown) => void>>;
+	_handleSidecarEvent(event: unknown): void;
+}
+
+function eventRouter(): {
+	probe: EventRouterProbe;
+	output: unknown[];
+	completed: unknown[];
+} {
+	const probe = Object.create(AgentOs.prototype) as EventRouterProbe;
+	probe._sidecarVm = { vmId: OWN_VM_ID };
+	probe._languageProcessIds = new Map();
+	probe._languageProcesses = new Map();
+	const output: unknown[] = [];
+	const completed: unknown[] = [];
+	probe._executionOutputHandlers = new Map([
+		["*", new Set([(event: unknown) => void output.push(event)])],
+	]);
+	probe._executionCompletedHandlers = new Map([
+		["*", new Set([(event: unknown) => void completed.push(event)])],
+	]);
+	return { probe, output, completed };
+}
+
+describe("cross-VM execution event isolation", () => {
+	test("an execution event owned by another VM is never dispatched here", () => {
+		const { probe, output, completed } = eventRouter();
+
+		probe._handleSidecarEvent(outputFrame(FOREIGN_VM_ID));
+		probe._handleSidecarEvent(completedFrame(FOREIGN_VM_ID));
+
+		expect(output).toEqual([]);
+		expect(completed).toEqual([]);
+	});
+
+	test("the same execution id owned by this VM is still dispatched", () => {
+		const { probe, output, completed } = eventRouter();
+
+		probe._handleSidecarEvent(outputFrame(OWN_VM_ID));
+		probe._handleSidecarEvent(completedFrame(OWN_VM_ID));
+
+		expect(output).toMatchObject([
+			{ executionId: COLLIDING_EXECUTION_ID, channel: "stdout" },
+		]);
+		expect(completed).toMatchObject([
+			{ executionId: COLLIDING_EXECUTION_ID, outcome: "succeeded" },
+		]);
+	});
+});


### PR DESCRIPTION
### The bug

`AgentOs._handleSidecarEvent` dispatches `execution_output` / `execution_completed` purely on `executionId`, over a **shared** sidecar client. Execution ids are minted per VM as `operation-{now_ms:x}-{per-VM counter:x}`, and the uniqueness loop only checks that VM's own map — there is no process-wide registry.

So two VMs whose Nth execution is admitted in the same millisecond mint the identical id. That is not an exotic race: the common fan-out (create K VMs together, each runs execution #1) puts every VM at the same counter ordinal simultaneously.

Impact when it fires: stdout/stderr chunks and completion (exit code, outcome) from VM B are delivered to VM A's handlers and process objects — a cross-VM data leak, not just a mixed-up log line.

### The fix

Two layers, both small:

1. **Ownership guard at the single shared entry point.** `_handleSidecarEvent` now drops any vm-scoped frame whose `event.ownership.vm_id` is not this instance's VM, *before* `mapExecutionOutputEvent` / `mapExecutionCompletedEvent` discard `ownership`. Because the guard sits in the one shared entry point, every id-keyed lookup downstream is VM-local by construction — including the in-flight `"*"` admission subscriptions, which needed no separate patch. Session- and connection-scoped events are not VM-specific and still pass through.

   This mirrors the pattern already used in the same file for the VM-readiness wait, which filters `ownership.scope === "vm" && ownership.vm_id === nativeVm.vmId`.

2. **Harden the mint at the source.** `language_execution.rs` now formats the public id from a process-wide `AtomicU64` instead of the per-VM counter, so ids are unique across VMs by construction. `VmState::next_public_execution_id` had no other reader and is removed.

### Why it is safe

- The guard only *drops* frames that provably belong to another VM; frames without vm scope are untouched, so session/connection lifecycle behaviour is unchanged.
- The mint change alters only the opaque id's suffix source. Ids stay unique within a VM (the previous property) and become unique across VMs (the new one); nothing parses their contents.
- `cargo build -p agentos-native-sidecar` is clean, and the new `packages/core/tests/cross-vm-execution-event-isolation.test.ts` covers the dispatch filter (2 tests, passing).

Found while running many concurrent VMs from one host process; happy to adjust the test's shape if you would rather drive it from a decoded `EventFrame` fixture than the instance-level probe.