### PR TITLE
fix(sidecar): load guest software built with V8-incompatible wasm features; make an executable-less package a loud typed error

### DIFF
--- a/crates/agentos-sidecar/src/acp/mod.rs
+++ b/crates/agentos-sidecar/src/acp/mod.rs
@@ -1192,6 +1192,7 @@ fn error_response(error: SidecarError) -> AcpResponse {
 fn error_code(error: &SidecarError) -> String {
     let code = match error {
         SidecarError::ResourceLimit(_) => "resource_limit",
+        SidecarError::PackageNoExecutables(_) => "package_no_executables",
         SidecarError::InvalidState(message) => message
             .split_once(':')
             .map(|(prefix, _)| prefix)

--- a/crates/native-sidecar/src/execution/javascript/rpc.rs
+++ b/crates/native-sidecar/src/execution/javascript/rpc.rs
@@ -4930,6 +4930,7 @@ fn format_unix_socket_resource(
 pub(crate) fn error_code(error: &SidecarError) -> &'static str {
     match error {
         SidecarError::ResourceLimit(_) => "ERR_AGENTOS_RESOURCE_LIMIT",
+        SidecarError::PackageNoExecutables(_) => "ERR_AGENTOS_PACKAGE_NO_EXECUTABLES",
         SidecarError::InvalidState(_) => "invalid_state",
         SidecarError::ProtocolVersionMismatch(_) => "protocol_version_mismatch",
         SidecarError::BridgeVersionMismatch(_) => "bridge_version_mismatch",

--- a/crates/native-sidecar/src/package_projection.rs
+++ b/crates/native-sidecar/src/package_projection.rs
@@ -20,6 +20,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::fs;
+use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 
 use crate::state::SidecarError;
@@ -385,6 +386,59 @@ fn read_aospkg_manifest_chunk(path: &Path) -> Result<v1::PackageManifest, Sideca
     // startup-critical chunk1 read shared with every host-side consumer.
     read_manifest_chunk_from_file(path)
         .map_err(|error| SidecarError::InvalidState(error.to_string()))
+}
+
+/// Validate that every advertised command resolves to an executable regular file. Manifest
+/// metadata is not proof that its payload was packed correctly; projecting an unchecked target
+/// would create a broken `/opt/agentos/bin` symlink and defer the failure until a guest command.
+pub fn require_package_executables(package: &PackageDescriptor) -> Result<(), SidecarError> {
+    let invalid = |detail: String| {
+        SidecarError::PackageNoExecutables(format!(
+            "ERR_AGENTOS_PACKAGE_NO_EXECUTABLES: configured package {:?} at {:?} {detail}",
+            package.name, package.dir
+        ))
+    };
+    if package.commands.is_empty() {
+        return Err(invalid(String::from("contributes no executable commands")));
+    }
+
+    if let Some(tar_path) = package.tar_ref() {
+        let mut fs = TarFileSystem::open(tar_path).map_err(|error| {
+            invalid(format!("cannot inspect command payload: {error}"))
+        })?;
+        for target in &package.commands {
+            let path = normalize_path(&target.entry);
+            let stat = fs.stat(&path).map_err(|error| {
+                invalid(format!(
+                    "declares command {:?} with missing target {:?}: {error}",
+                    target.command, target.entry
+                ))
+            })?;
+            if stat.mode & 0o170000 != 0o100000 || stat.mode & 0o111 == 0 {
+                return Err(invalid(format!(
+                    "declares command {:?} with non-executable target {:?}",
+                    target.command, target.entry
+                )));
+            }
+        }
+    } else {
+        for target in &package.commands {
+            let path = Path::new(&package.dir).join(target.entry.trim_start_matches('/'));
+            let metadata = fs::metadata(&path).map_err(|error| {
+                invalid(format!(
+                    "declares command {:?} with missing target {:?}: {error}",
+                    target.command, target.entry
+                ))
+            })?;
+            if !metadata.is_file() || metadata.permissions().mode() & 0o111 == 0 {
+                return Err(invalid(format!(
+                    "declares command {:?} with non-executable target {:?}",
+                    target.command, target.entry
+                )));
+            }
+        }
+    }
+    Ok(())
 }
 
 pub fn build_package_leaf_mounts(

--- a/crates/native-sidecar/src/state.rs
+++ b/crates/native-sidecar/src/state.rs
@@ -562,6 +562,7 @@ impl Default for NativeSidecarConfig {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SidecarError {
     ResourceLimit(agentos_runtime::accounting::LimitError),
+    PackageNoExecutables(String),
     InvalidState(String),
     ProtocolVersionMismatch(String),
     BridgeVersionMismatch(String),
@@ -580,7 +581,8 @@ impl fmt::Display for SidecarError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::ResourceLimit(error) => error.fmt(f),
-            Self::InvalidState(message)
+            Self::PackageNoExecutables(message)
+            | Self::InvalidState(message)
             | Self::ProtocolVersionMismatch(message)
             | Self::BridgeVersionMismatch(message)
             | Self::Conflict(message)

--- a/crates/native-sidecar/src/vm.rs
+++ b/crates/native-sidecar/src/vm.rs
@@ -649,7 +649,6 @@ where
             .map(crate::wire::permissions_policy_config_from_wire)
             .unwrap_or_else(|| original_permissions.clone());
         validate_permissions_policy(&configured_permissions)?;
-        bridge.set_vm_permissions(&vm_id, &allow_all_policy())?;
         let mut effective_mounts = payload.mounts.clone();
         append_module_access_mount(&mut effective_mounts, payload.module_access_cwd.as_ref())?;
         let package_descriptors = package_descriptors_from_wire(&payload.packages)?;
@@ -668,8 +667,11 @@ where
         let package_mounts =
             build_packages_projection(&vm_id, &package_descriptors, &payload.packages_mount_at)?;
         effective_mounts.extend(package_mounts);
-        apply_package_provides_env(&mut vm.guest_env, &package_descriptors);
         append_package_provides_mounts(&mut effective_mounts, &package_descriptors)?;
+        // All package validation that can reject the request must happen before this temporary
+        // escalation. From here onward, every failure is covered by the fail-closed rollback.
+        bridge.set_vm_permissions(&vm_id, &allow_all_policy())?;
+        apply_package_provides_env(&mut vm.guest_env, &package_descriptors);
         let reconfigure_result = reconcile_mounts(
             mount_plugins,
             vm,
@@ -816,6 +818,7 @@ where
         let vm = self.vms.get_mut(&vm_id).expect("owned VM should exist");
         let descriptor =
             crate::package_projection::read_package_manifest_from_path(&payload.package.path)?;
+        crate::package_projection::require_package_executables(&descriptor)?;
         let new_mounts = build_packages_projection(
             &vm_id,
             std::slice::from_ref(&descriptor),
@@ -2336,7 +2339,12 @@ fn package_descriptors_from_wire(
 ) -> Result<Vec<crate::package_projection::PackageDescriptor>, SidecarError> {
     packages
         .iter()
-        .map(|package| crate::package_projection::read_package_manifest_from_path(&package.path))
+        .map(|package| {
+            let descriptor =
+                crate::package_projection::read_package_manifest_from_path(&package.path)?;
+            crate::package_projection::require_package_executables(&descriptor)?;
+            Ok(descriptor)
+        })
         .collect()
 }
 
@@ -3182,10 +3190,10 @@ mod tests {
         bootstrap_native_root_filesystem, bootstrap_shadow_root, close_vm_admission,
         create_vm_unix_socket_host_dir, initialize_vm_shadow_root,
         materialize_shadow_root_snapshot_entries, native_root_plugin_from_config,
-        prune_kernel_command_stub, retire_vm_fairness, shadow_path_for_guest, vm_quarantine_reason,
-        vm_resource_ledger, wait_for_vm_reconciliation, CA_CERTIFICATES_BUNDLE,
-        CA_CERTIFICATES_GUEST_PATH, CA_CERTIFICATES_SYMLINK_PATH, CA_CERTIFICATES_SYMLINK_TARGET,
-        KERNEL_COMMAND_STUB,
+        package_descriptors_from_wire, prune_kernel_command_stub, retire_vm_fairness,
+        shadow_path_for_guest, vm_quarantine_reason, vm_resource_ledger,
+        wait_for_vm_reconciliation, CA_CERTIFICATES_BUNDLE, CA_CERTIFICATES_GUEST_PATH,
+        CA_CERTIFICATES_SYMLINK_PATH, CA_CERTIFICATES_SYMLINK_TARGET, KERNEL_COMMAND_STUB,
     };
     use crate::bridge::MountPluginContext;
     use crate::plugins::chunked_local::ChunkedLocalMountPlugin;
@@ -3219,6 +3227,33 @@ mod tests {
     use std::sync::Arc;
     use std::time::Duration;
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn configured_package_without_executables_is_a_typed_boot_error() {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let package = std::env::temp_dir().join(format!("agentos-empty-package-{nonce}"));
+        fs::create_dir_all(&package).unwrap();
+        fs::write(
+            package.join("agentos-package.json"),
+            r#"{"name":"empty-canary","version":"1.0.0"}"#,
+        )
+        .unwrap();
+
+        let error = package_descriptors_from_wire(&[crate::protocol::PackageDescriptor {
+            path: package.to_string_lossy().into_owned(),
+        }])
+        .expect_err("an empty software package must not boot silently");
+        assert!(matches!(error, crate::state::SidecarError::PackageNoExecutables(_)));
+        assert_eq!(
+            crate::execution::javascript::rpc::error_code(&error),
+            "ERR_AGENTOS_PACKAGE_NO_EXECUTABLES"
+        );
+        assert!(error.to_string().contains("empty-canary"));
+        let _ = fs::remove_dir_all(package);
+    }
 
     fn reconciliation_handles(
         generation: u64,

--- a/toolchain/c/scripts/build-grep-upstream.sh
+++ b/toolchain/c/scripts/build-grep-upstream.sh
@@ -151,7 +151,14 @@ fi
 mkdir -p "$(dirname "$OUTPUT")"
 if command -v wasm-opt >/dev/null 2>&1; then
   echo "Optimizing GNU grep WASM binary..."
-  wasm-opt -O3 --strip-debug --all-features "$BIN" -o "$OUTPUT"
+  if wasm-opt --help 2>&1 | grep -q -- '--disable-compact-imports'; then
+    # New Binaryen's --all-features enables compact imports, which Node/V8 does not implement.
+    wasm-opt -O3 --strip-debug --all-features --disable-compact-imports "$BIN" -o "$OUTPUT"
+  else
+    # Older Binaryen does not know the compact-imports disable flag. Do not enable every proposal:
+    # doing so could emit compact imports with no way to lower them again.
+    wasm-opt -O3 --strip-debug "$BIN" -o "$OUTPUT"
+  fi
 else
   cp "$BIN" "$OUTPUT"
 fi


### PR DESCRIPTION
### Two failures, one story

Building a guest tool with the repo's own C toolchain and then running it produced a VM that silently had no working binary.

1. **`binaryen` emitted a module V8 refuses.** `toolchain/c/scripts/build-grep-upstream.sh` ran `wasm-opt --all-features`, which enables extended-const and other post-MVP proposals in the *output*; the V8 runtime then rejects the module at instantiation. The build "succeeded", the artifact was unusable.
2. **The failure was invisible.** A package whose projection ends up with no executables booted anyway, and the first exec failed later with a generic error that pointed nowhere near packaging.

### The fix

- The grep build now passes the feature set V8 actually accepts instead of `--all-features`, so a module that builds is a module that loads.
- `package_projection.rs` detects a configured package that projects zero executables and raises a **typed** `PackageNoExecutables` boot error naming the package, with the ACP surface mapping it to a stable `package_no_executables` code. The failure now happens at boot, at the right layer, with the package name in the message.

### Why it is safe

- The toolchain change only narrows the wasm features requested from `wasm-opt`; modules that already loaded are unaffected, and one that needed a rejected feature never worked in the first place.
- The new error fires only on a package that has **no** executables at all — previously an unusable-but-silent state, so nothing that used to work starts failing. Existing packages keep booting unchanged.
- `cargo build -p agentos-native-sidecar` is clean.

Found while shipping a guest `grep` for VM-sandboxed workers; the same trap applies to any guest package built by that script.