### PR TITLE
fix(core): remove unused isolated-vm dependency

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -76,7 +76,6 @@
 		"better-sqlite3": "^12.8.0",
 		"croner": "^10.0.1",
 		"googleapis": "^144.0.0",
-		"isolated-vm": "^6.0.0",
 		"long-timeout": "^0.1.1",
 		"minimatch": "^10.2.4",
 		"zod": "^4.1.11",

--- a/packages/core/pnpm-lock.yaml
+++ b/packages/core/pnpm-lock.yaml
@@ -26,9 +26,6 @@ importers:
       googleapis:
         specifier: ^144.0.0
         version: 144.0.0
-      isolated-vm:
-        specifier: ^6.0.0
-        version: 6.1.2
       long-timeout:
         specifier: ^0.1.1
         version: 0.1.1
@@ -2077,10 +2074,6 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
-  isolated-vm@6.1.2:
-    resolution: {integrity: sha512-GGfsHqtlZiiurZaxB/3kY7LLAXR3sgzDul0fom4cSyBjx6ZbjpTrFWiH3z/nUfLJGJ8PIq9LQmQFiAxu24+I7A==}
-    engines: {node: '>=22.0.0'}
-
   isomorphic-timers-promises@1.0.1:
     resolution: {integrity: sha512-u4sej9B1LPSxTGKB/HiuzvEQnXH0ECYkSVQU39koSwmFAxhlEAFl9RdTvLv4TOTQUgBS5O3O5fwUxk6byBZ+IQ==}
     engines: {node: '>=10'}
@@ -2233,10 +2226,6 @@ packages:
   node-fetch@3.3.2:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
-  node-gyp-build@4.8.4:
-    resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
-    hasBin: true
 
   node-stdlib-browser@1.3.1:
     resolution: {integrity: sha512-X75ZN8DCLftGM5iKwoYLA3rjnrAEs97MkzvSd4q2746Tgpg8b8XWiBGiBG4ZpgcAqBgtgPHTiAc8ZMCvZuikDw==}
@@ -5346,10 +5335,6 @@ snapshots:
 
   isexe@2.0.0: {}
 
-  isolated-vm@6.1.2:
-    dependencies:
-      node-gyp-build: 4.8.4
-
   isomorphic-timers-promises@1.0.1: {}
 
   jose@6.2.2: {}
@@ -5471,8 +5456,6 @@ snapshots:
       data-uri-to-buffer: 4.0.1
       fetch-blob: 3.2.0
       formdata-polyfill: 4.0.10
-
-  node-gyp-build@4.8.4: {}
 
   node-stdlib-browser@1.3.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3045,9 +3045,6 @@ importers:
       googleapis:
         specifier: ^144.0.0
         version: 144.0.0
-      isolated-vm:
-        specifier: ^6.0.0
-        version: 6.1.2
       long-timeout:
         specifier: ^0.1.1
         version: 0.1.1
@@ -9644,10 +9641,6 @@ packages:
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
-
-  isolated-vm@6.1.2:
-    resolution: {integrity: sha512-GGfsHqtlZiiurZaxB/3kY7LLAXR3sgzDul0fom4cSyBjx6ZbjpTrFWiH3z/nUfLJGJ8PIq9LQmQFiAxu24+I7A==}
-    engines: {node: '>=22.0.0'}
 
   isomorphic-timers-promises@1.0.1:
     resolution: {integrity: sha512-u4sej9B1LPSxTGKB/HiuzvEQnXH0ECYkSVQU39koSwmFAxhlEAFl9RdTvLv4TOTQUgBS5O3O5fwUxk6byBZ+IQ==}
@@ -18122,10 +18115,6 @@ snapshots:
   isarray@2.0.5: {}
 
   isexe@2.0.0: {}
-
-  isolated-vm@6.1.2:
-    dependencies:
-      node-gyp-build: 4.8.4
 
   isomorphic-timers-promises@1.0.1: {}
 


### PR DESCRIPTION
- Remove the unused native isolated-vm dependency from agentOS core.\n- Prune isolated-vm from the workspace and standalone core lockfiles.\n- Keep downstream installs free of the unnecessary native build dependency.