### PR TITLE
fix(release): restore publish builds

### DIFF
--- a/packages/agentos/src/shell-replay.ts
+++ b/packages/agentos/src/shell-replay.ts
@@ -34,6 +34,13 @@ interface GhosttyModule {
 	): HeadlessTerminal;
 }
 
+interface WebAssemblyRuntime {
+	instantiate(
+		bytes: Uint8Array,
+		imports: Record<string, Record<string, () => void>>,
+	): Promise<{ instance: object }>;
+}
+
 interface GhosttyCell {
 	codepoint: number;
 	fg_r: number;
@@ -75,10 +82,19 @@ async function loadGhostty(): Promise<GhosttyModule> {
 		const bytes = await readFile(
 			require.resolve("ghostty-web/ghostty-vt.wasm"),
 		);
-		const { instance } = await WebAssembly.instantiate(bytes, {
+		const webAssembly = Reflect.get(globalThis, "WebAssembly") as
+			| WebAssemblyRuntime
+			| undefined;
+		if (!webAssembly) {
+			throw new Error("WebAssembly is unavailable in this runtime");
+		}
+		const { instance } = await webAssembly.instantiate(bytes, {
 			env: { log: () => {} },
 		});
-		return new Ghostty(instance) as unknown as GhosttyModule;
+		const GhosttyConstructor = Ghostty as unknown as new (
+			instance: object,
+		) => GhosttyModule;
+		return new GhosttyConstructor(instance);
 	})();
 	return ghosttyPromise;
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -31,13 +31,6 @@ packages:
   - examples/*/*
   - experiments/gigacode
   - scripts/publish
-  # LOCAL WORKAROUND (do not commit): `website` needs @rivet-dev/docs-theme
-  # symlinked into website/vendor/theme, which isn't set up here and blocks
-  # `pnpm install` workspace-wide. Excluded to build/run the demo locally.
-  - website
-  - website/vendor/theme
-  - website/vendor/theme/vendor/components
-  - website/vendor/theme/vendor/icons
 
 ignoredBuiltDependencies:
   - '@clerk/shared'


### PR DESCRIPTION
- Remove retired website workspaces that break frozen installs in publish jobs
- Keep the agentOS package build independent of ambient DOM WebAssembly types
- Validate the frozen install and publishable package build locally