### PR TITLE
fix: prevent owned VM fetch wakeup starvation

### DIFF
--- a/crates/execution/src/javascript.rs
+++ b/crates/execution/src/javascript.rs
@@ -6926,7 +6926,20 @@ fn builtin_named_exports(module_name: &str) -> &'static [&'static str] {
             "validateHeaderName",
             "validateHeaderValue",
         ],
-        "http2" => &["connect", "createServer", "createSecureServer"],
+        "http2" => &[
+            "Http2ServerRequest",
+            "Http2ServerResponse",
+            "Http2Session",
+            "Http2Stream",
+            "connect",
+            "constants",
+            "createServer",
+            "createSecureServer",
+            "getDefaultSettings",
+            "getPackedSettings",
+            "getUnpackedSettings",
+            "sensitiveHeaders",
+        ],
         "https" => &[
             "Agent",
             "ClientRequest",
@@ -7456,6 +7469,14 @@ mod tests {
     use std::io::BufRead;
     use std::time::{SystemTime, UNIX_EPOCH};
     use tempfile::tempdir;
+
+    #[test]
+    fn http2_builtin_exposes_node_compatibility_classes() {
+        let exports = builtin_named_exports("http2");
+        assert!(exports.contains(&"Http2ServerRequest"));
+        assert!(exports.contains(&"Http2ServerResponse"));
+        assert!(exports.contains(&"constants"));
+    }
 
     #[test]
     fn dispose_context_reclaims_one_shot_metadata_without_reusing_ids() {

--- a/crates/kernel/src/socket_table.rs
+++ b/crates/kernel/src/socket_table.rs
@@ -19,6 +19,7 @@ pub type SocketResult<T> = Result<T, SocketTableError>;
 pub enum SocketReadinessKind {
     Data,
     Accept,
+    Hangup,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -2423,8 +2424,23 @@ impl SocketTable {
     }
 
     pub fn remove(&self, socket_id: SocketId) -> SocketResult<SocketRecord> {
-        let mut table = lock_or_recover(&self.inner.state);
-        remove_socket(&mut table, socket_id).ok_or_else(|| SocketTableError::not_found(socket_id))
+        let (record, readiness) = {
+            let mut table = lock_or_recover(&self.inner.state);
+            let record = remove_socket(&mut table, socket_id)
+                .ok_or_else(|| SocketTableError::not_found(socket_id))?;
+            let readiness = record
+                .connection_state
+                .as_ref()
+                .and_then(|connection| connection.peer_socket_id)
+                .filter(|peer_socket_id| table.sockets.contains_key(peer_socket_id))
+                .map(|peer_socket_id| SocketReadiness {
+                    socket_id: peer_socket_id,
+                    kind: SocketReadinessKind::Hangup,
+                });
+            (record, readiness)
+        };
+        self.emit_readiness(readiness);
+        Ok(record)
     }
 
     pub fn remove_all_for_pid(&self, owner_pid: u32) -> Vec<SocketRecord> {

--- a/crates/kernel/tests/loopback_routing.rs
+++ b/crates/kernel/tests/loopback_routing.rs
@@ -253,6 +253,16 @@ fn kernel_loopback_readiness_events_are_edge_triggered() {
             kind: SocketReadinessKind::Data,
         }]
     );
+    kernel
+        .socket_close("shell", client.pid(), client_socket)
+        .expect("close loopback client");
+    assert_eq!(
+        take_readiness_events(&events),
+        vec![SocketReadiness {
+            socket_id: accepted,
+            kind: SocketReadinessKind::Hangup,
+        }]
+    );
 
     let udp_sender = kernel
         .socket_create("shell", client.pid(), SocketSpec::udp())

--- a/crates/native-sidecar/src/execution/coordinator.rs
+++ b/crates/native-sidecar/src/execution/coordinator.rs
@@ -690,12 +690,11 @@ where
         payload: VmFetchRequest,
     ) -> OwnedVmRouteFuture {
         let input = self.prepare_owned_vm_route(request);
-        let bridge = self.bridge.clone();
         let max_frame_bytes = self.config.max_frame_bytes;
         Box::pin(async move {
             let input = input?;
             let response_json =
-                dispatch_owned_vm_fetch(bridge, &input.vm_id, input.vm.clone(), payload).await?;
+                dispatch_owned_vm_fetch(&input.vm_id, input.vm.clone(), payload).await?;
             let response = agentos_native_sidecar_core::respond(
                 &input.request,
                 ResponsePayload::VmFetchResult(VmFetchResponse { response_json }),

--- a/crates/native-sidecar/src/execution/javascript/http.rs
+++ b/crates/native-sidecar/src/execution/javascript/http.rs
@@ -1721,104 +1721,6 @@ where
     settle_owned_fetch_sync_rpc::<B>(vm, process_id, child_path, request, response).await
 }
 
-/// Poll and service one event for the private VM-fetch loop. Protocol-router
-/// process events use `service_owned_javascript_sync_rpc_request` after claiming
-/// the concrete event, preserving the broker's one-consumer rule.
-pub(crate) async fn service_owned_root_javascript_event<B>(
-    bridge: &SharedBridge<B>,
-    vm_id: &str,
-    vm: &crate::state::VmHandle,
-    process_id: &str,
-    preserve_http_wait: bool,
-) -> Result<bool, SidecarError>
-where
-    B: NativeSidecarBridge + Send + 'static,
-    BridgeError<B>: fmt::Debug + Send + Sync + 'static,
-{
-    enum Turn {
-        Idle,
-        Serviced,
-        Response {
-            request: JavascriptSyncRpcRequest,
-            response: Result<JavascriptSyncRpcServiceResponse, SidecarError>,
-        },
-    }
-
-    let turn = vm.try_command("service owned VM fetch target", |vm| {
-        let socket_paths = build_javascript_socket_path_context(vm)?;
-        let dns = vm.dns.clone();
-        let kernel_readiness = Arc::clone(&vm.kernel_socket_readiness);
-        let capabilities = vm.capabilities.clone();
-        let VmState {
-            kernel,
-            active_processes,
-            ..
-        } = vm;
-        let process = active_processes.get_mut(process_id).ok_or_else(|| {
-            SidecarError::InvalidState(format!("vm.fetch target process disappeared: {process_id}"))
-        })?;
-        let event = process
-            .execution
-            .try_poll_event()
-            .map_err(|error| SidecarError::Execution(error.to_string()))?;
-        let Some(event) = event else {
-            return Ok(Turn::Idle);
-        };
-        match event {
-            ActiveExecutionEvent::JavascriptSyncRpcRequest(request)
-                if preserve_http_wait && request.method == "net.http_wait" =>
-            {
-                process.queue_pending_execution_event(
-                    ActiveExecutionEvent::JavascriptSyncRpcRequest(request),
-                )?;
-                Ok(Turn::Serviced)
-            }
-            ActiveExecutionEvent::JavascriptSyncRpcRequest(request) => {
-                let mut future = Box::pin(service_javascript_sync_rpc(
-                    JavascriptSyncRpcServiceRequest {
-                        bridge,
-                        vm_id,
-                        dns: &dns,
-                        socket_paths: &socket_paths,
-                        kernel,
-                        kernel_readiness,
-                        process,
-                        sync_request: &request,
-                        capabilities,
-                    },
-                ));
-                let mut context = Context::from_waker(Waker::noop());
-                let poll = future.as_mut().poll(&mut context);
-                drop(future);
-                match poll {
-                    Poll::Ready(response) => Ok(Turn::Response { request, response }),
-                    Poll::Pending => {
-                        process.queue_pending_execution_event(
-                            ActiveExecutionEvent::JavascriptSyncRpcRequest(request),
-                        )?;
-                        Ok(Turn::Serviced)
-                    }
-                }
-            }
-            ActiveExecutionEvent::Exited(code) => Err(SidecarError::Execution(format!(
-                "vm.fetch target exited before responding (exit code {code})"
-            ))),
-            other => {
-                process.queue_pending_execution_event(other)?;
-                Ok(Turn::Serviced)
-            }
-        }
-    })?;
-    match turn {
-        Turn::Idle => Ok(false),
-        Turn::Serviced => Ok(true),
-        Turn::Response { request, response } => {
-            settle_owned_fetch_sync_rpc::<B>(vm, process_id, &[], request, response).await?;
-            Ok(true)
-        }
-    }
-}
-
 fn owned_fetch_process_notify(
     vm: &crate::state::VmHandle,
     process_id: &str,
@@ -1836,7 +1738,7 @@ fn owned_fetch_process_notify(
 }
 
 async fn wait_for_owned_fetch_progress(
-    socket: &OwnedKernelFetchSocket,
+    readiness_notify: &Arc<tokio::sync::Notify>,
     process_notify: &Arc<tokio::sync::Notify>,
     deadline: Instant,
 ) -> Result<(), SidecarError> {
@@ -1848,8 +1750,14 @@ async fn wait_for_owned_fetch_progress(
     }
     tokio::time::timeout(remaining, async {
         tokio::select! {
-            _ = socket.readiness_notify.notified() => {},
-            _ = process_notify.notified() => {},
+            _ = readiness_notify.notified() => {},
+            _ = tokio::time::sleep(Duration::from_millis(1)) => {
+                // The ordinary dispatcher exclusively owns guest execution
+                // events. Wake it so runnable microtask or WASM work advances;
+                // this fetch path only owns the kernel response socket.
+                process_notify.notify_one();
+                tokio::task::yield_now().await;
+            },
         }
     })
     .await
@@ -1862,9 +1770,7 @@ async fn wait_for_owned_fetch_progress(
     Ok(())
 }
 
-async fn dispatch_owned_kernel_http_fetch<B>(
-    bridge: &SharedBridge<B>,
-    vm_id: &str,
+async fn dispatch_owned_kernel_http_fetch(
     vm: &crate::state::VmHandle,
     target_process_id: &str,
     port: u16,
@@ -1873,11 +1779,7 @@ async fn dispatch_owned_kernel_http_fetch<B>(
     headers: &HttpHeaderCollection,
     body_bytes: Option<&[u8]>,
     max_fetch_response_bytes: usize,
-) -> Result<String, SidecarError>
-where
-    B: NativeSidecarBridge + Send + 'static,
-    BridgeError<B>: fmt::Debug + Send + Sync + 'static,
-{
+) -> Result<String, SidecarError> {
     let mut socket = open_owned_kernel_fetch_socket(
         vm,
         target_process_id,
@@ -1911,23 +1813,20 @@ where
                 preview.chars().take(200).collect::<String>()
             )));
         }
-        let serviced =
-            service_owned_root_javascript_event(bridge, vm_id, vm, target_process_id, true).await?;
         let progressed = poll_owned_kernel_fetch_socket(
             &socket,
             &mut response_buffer,
             &mut peer_closed,
             "vm.fetch",
         )?;
-        if !progressed && !serviced {
-            wait_for_owned_fetch_progress(&socket, &process_notify, deadline).await?;
+        if !progressed {
+            wait_for_owned_fetch_progress(&socket.readiness_notify, &process_notify, deadline)
+                .await?;
         }
     }
 }
 
-async fn start_owned_kernel_http_fetch_stream<B>(
-    bridge: &SharedBridge<B>,
-    vm_id: &str,
+async fn start_owned_kernel_http_fetch_stream(
     vm: &crate::state::VmHandle,
     target_process_id: &str,
     port: u16,
@@ -1936,11 +1835,7 @@ async fn start_owned_kernel_http_fetch_stream<B>(
     headers: &HttpHeaderCollection,
     body_bytes: Option<&[u8]>,
     max_response_bytes: usize,
-) -> Result<String, SidecarError>
-where
-    B: NativeSidecarBridge + Send + 'static,
-    BridgeError<B>: fmt::Debug + Send + Sync + 'static,
-{
+) -> Result<String, SidecarError> {
     let socket = open_owned_kernel_fetch_socket(
         vm,
         target_process_id,
@@ -1981,16 +1876,15 @@ where
                 http_loopback_request_timeout().as_millis()
             )));
         }
-        let serviced =
-            service_owned_root_javascript_event(bridge, vm_id, vm, target_process_id, true).await?;
         let progressed = poll_owned_kernel_fetch_socket(
             &socket,
             &mut response_buffer,
             &mut peer_closed,
             "vm.fetchStream",
         )?;
-        if !progressed && !serviced {
-            wait_for_owned_fetch_progress(&socket, &process_notify, deadline).await?;
+        if !progressed {
+            wait_for_owned_fetch_progress(&socket.readiness_notify, &process_notify, deadline)
+                .await?;
         }
     };
 
@@ -2137,17 +2031,11 @@ fn lease_owned_fetch_stream(
     })
 }
 
-async fn read_owned_kernel_http_fetch_stream<B>(
-    bridge: &SharedBridge<B>,
-    vm_id: &str,
+async fn read_owned_kernel_http_fetch_stream(
     vm: &crate::state::VmHandle,
     stream_id: &str,
     requested_max_bytes: usize,
-) -> Result<String, SidecarError>
-where
-    B: NativeSidecarBridge + Send + 'static,
-    BridgeError<B>: fmt::Debug + Send + Sync + 'static,
-{
+) -> Result<String, SidecarError> {
     let max_bytes = requested_max_bytes.clamp(1, VM_FETCH_STREAM_CHUNK_MAX_BYTES);
     let mut lease = lease_owned_fetch_stream(vm, stream_id)?;
     let target_process_id = lease.state().target_process_id.clone();
@@ -2166,9 +2054,6 @@ where
                 http_loopback_request_timeout().as_millis()
             )));
         }
-        let serviced =
-            service_owned_root_javascript_event(bridge, vm_id, vm, &target_process_id, true)
-                .await?;
         let (kernel_pid, socket_id) = (lease.state().kernel_pid, lease.state().socket_id);
         let mut raw_buffer = std::mem::take(&mut lease.state_mut().raw_buffer);
         let mut peer_closed = lease.state().peer_closed;
@@ -2231,21 +2116,9 @@ where
         lease.state_mut().peer_closed = peer_closed;
         if progressed {
             lease.state_mut().last_progress_at = Instant::now();
-        } else if !serviced {
-            let remaining = deadline.saturating_duration_since(Instant::now());
-            tokio::time::timeout(remaining, async {
-                tokio::select! {
-                    _ = lease.readiness_notify.notified() => {},
-                    _ = process_notify.notified() => {},
-                }
-            })
-                .await
-                .map_err(|_| {
-                    SidecarError::Execution(format!(
-                        "ERR_AGENTOS_VM_FETCH_TIMEOUT: stream produced no data for {} ms; raise AGENTOS_HTTP_LOOPBACK_REQUEST_TIMEOUT_MS",
-                        http_loopback_request_timeout().as_millis()
-                    ))
-                })?;
+        } else {
+            wait_for_owned_fetch_progress(&lease.readiness_notify, &process_notify, deadline)
+                .await?;
         }
     }
 
@@ -2358,16 +2231,11 @@ async fn dispatch_owned_loopback_http_request(
 
 /// Run `vm.fetch` without holding either the process coordinator or a VM state
 /// borrow over readiness and adapter-response waits.
-pub(in crate::execution) async fn dispatch_owned_vm_fetch<B>(
-    bridge: SharedBridge<B>,
+pub(in crate::execution) async fn dispatch_owned_vm_fetch(
     vm_id: &str,
     vm: crate::state::VmHandle,
     payload: VmFetchRequest,
-) -> Result<String, SidecarError>
-where
-    B: NativeSidecarBridge + Send + 'static,
-    BridgeError<B>: fmt::Debug + Send + Sync + 'static,
-{
+) -> Result<String, SidecarError> {
     let stream_operation = payload.stream_operation.as_deref();
     if matches!(stream_operation, Some("read" | "cancel")) {
         let stream_id = payload.stream_id.as_deref().ok_or_else(|| {
@@ -2377,8 +2245,6 @@ where
         })?;
         return if stream_operation == Some("read") {
             read_owned_kernel_http_fetch_stream(
-                &bridge,
-                vm_id,
                 &vm,
                 stream_id,
                 payload.max_bytes.unwrap_or(64 * 1024) as usize,
@@ -2440,8 +2306,6 @@ where
     if let Some(target_process_id) = kernel_target {
         return if stream_operation == Some("start") {
             start_owned_kernel_http_fetch_stream(
-                &bridge,
-                vm_id,
                 &vm,
                 &target_process_id,
                 payload.port,
@@ -2454,8 +2318,6 @@ where
             .await
         } else {
             dispatch_owned_kernel_http_fetch(
-                &bridge,
-                vm_id,
                 &vm,
                 &target_process_id,
                 payload.port,

--- a/crates/native-sidecar/src/vm.rs
+++ b/crates/native-sidecar/src/vm.rs
@@ -175,6 +175,9 @@ fn send_kernel_socket_readiness_event(
         (KernelSocketReadinessEvent::Data, SocketReadinessKind::Data) => {
             agentos_runtime::readiness::ReadyFlags::READABLE
         }
+        (KernelSocketReadinessEvent::Data, SocketReadinessKind::Hangup) => {
+            agentos_runtime::readiness::ReadyFlags::END
+        }
         (KernelSocketReadinessEvent::Datagram, SocketReadinessKind::Data) => {
             agentos_runtime::readiness::ReadyFlags::DATAGRAM
         }

--- a/packages/build-tools/bridge-src/builtins/http.ts
+++ b/packages/build-tools/bridge-src/builtins/http.ts
@@ -4239,7 +4239,7 @@ function attachHttpServerSocket(server, socket) {
   const onEnd = () => {
     ended = true;
     if (buffer.length === 0) {
-      cleanup();
+      finishSocket();
       return;
     }
     scheduleDispatch();

--- a/packages/core/tests/network-http-request.test.ts
+++ b/packages/core/tests/network-http-request.test.ts
@@ -1,5 +1,6 @@
 import { createServer } from "node:http";
 import { afterEach, describe, expect, test } from "vitest";
+import { WebSocketServer } from "ws";
 import { AgentOs } from "../src/index.js";
 
 const textDecoder = new TextDecoder();
@@ -54,10 +55,10 @@ describe("guest http.request transport", () => {
 			'  socket.on("data", (chunk) => {',
 			"    buffered += chunk;",
 			'    if (!buffered.includes("\\r\\n\\r\\n")) return;',
-			'    socket.end([',
+			"    socket.end([",
 			'      "HTTP/1.1 200 OK",',
 			'      "Content-Type: application/json",',
-			'      `Content-Length: ${Buffer.byteLength(body)}`,',
+			"      `Content-Length: ${Buffer.byteLength(body)}`,",
 			'      "Connection: close",',
 			'      "",',
 			"      body,",
@@ -71,7 +72,7 @@ describe("guest http.request transport", () => {
 			"    process.exit(1);",
 			"    return;",
 			"  }",
-			'  const req = http.get(`http://127.0.0.1:${address.port}/transport-check`, (res) => {',
+			"  const req = http.get(`http://127.0.0.1:${address.port}/transport-check`, (res) => {",
 			'    let responseBody = "";',
 			'    res.setEncoding("utf8");',
 			'    res.on("data", (chunk) => {',
@@ -79,12 +80,12 @@ describe("guest http.request transport", () => {
 			"    });",
 			'    res.on("end", () => {',
 			"      console.log(JSON.stringify({ statusCode: res.statusCode, body: responseBody }));",
-			'      server.close(() => process.exit(0));',
+			"      server.close(() => process.exit(0));",
 			"    });",
 			"  });",
 			'  req.on("error", (error) => {',
-			'    console.error(error?.stack ?? String(error));',
-			'    server.close(() => process.exit(1));',
+			"    console.error(error?.stack ?? String(error));",
+			"    server.close(() => process.exit(1));",
 			"  });",
 			"});",
 		].join("\n");
@@ -176,11 +177,11 @@ describe("guest http.request transport", () => {
 			'const http = require("node:http");',
 			"void (async () => {",
 			"const server = http.createServer((request, response) => {",
-			'  response.end(`self:${request.url}`);',
+			"  response.end(`self:${request.url}`);",
 			"});",
 			'await new Promise((resolve, reject) => { server.once("error", reject); server.listen(0, "127.0.0.1", resolve); });',
 			"const address = server.address();",
-			'const response = await fetch(`http://127.0.0.1:${address.port}/self-fetch`);',
+			"const response = await fetch(`http://127.0.0.1:${address.port}/self-fetch`);",
 			"console.log(await response.text());",
 			"await new Promise((resolve) => server.close(resolve));",
 			"})();",
@@ -215,12 +216,12 @@ describe("guest http.request transport", () => {
 			'    response.write("data: ready\\n\\n");',
 			"    return;",
 			"  }",
-			'  response.end(`control:${request.url}`);',
+			"  response.end(`control:${request.url}`);",
 			"});",
 			'await new Promise((resolve, reject) => { server.once("error", reject); server.listen(0, "127.0.0.1", resolve); });',
 			"const address = server.address();",
 			"const abort = new AbortController();",
-			'const events = await fetch(`http://127.0.0.1:${address.port}/events`, { signal: abort.signal });',
+			"const events = await fetch(`http://127.0.0.1:${address.port}/events`, { signal: abort.signal });",
 			"const reader = events.body.getReader();",
 			"await reader.read();",
 			"const controls = [];",
@@ -241,9 +242,115 @@ describe("guest http.request transport", () => {
 
 		expect(result, result.stderr).toMatchObject({
 			exitCode: 0,
-			stdout: "control:/control-0,control:/control-1,control:/control-2,control:/control-3,control:/control-4\n",
+			stdout:
+				"control:/control-0,control:/control-1,control:/control-2,control:/control-3,control:/control-4\n",
 			stderr: "",
 		});
+	});
+
+	test("streams a guest response after the handler opens an outbound websocket", async () => {
+		const upstream = createServer();
+		const upstreamWebSocket = new WebSocketServer({ server: upstream });
+		upstreamWebSocket.on("connection", (socket) => {
+			socket.once("message", () => {
+				socket.send(Uint8Array.from([1, 2, 3]), { binary: true });
+			});
+		});
+		await new Promise<void>((resolve) =>
+			upstream.listen(0, "127.0.0.1", resolve),
+		);
+		const upstreamAddress = upstream.address();
+		if (!upstreamAddress || typeof upstreamAddress === "string") {
+			throw new Error("missing upstream TCP address");
+		}
+
+		try {
+			vm = await AgentOs.create({
+				sidecar: { kind: "shared", pool: "reentrant-websocket-test" },
+				loopbackExemptPorts: [upstreamAddress.port],
+				permissions: {
+					fs: "allow",
+					network: "allow",
+					childProcess: "allow",
+				},
+			});
+
+			let resolveReady = () => {};
+			let stderr = "";
+			const ready = new Promise<void>((resolve) => {
+				resolveReady = resolve;
+			});
+			const script = [
+				'const http = require("node:http");',
+				"const server = http.createServer(async (_request, response) => {",
+				`  const socket = new WebSocket("ws://127.0.0.1:${upstreamAddress.port}/", ["rivet", "rivet_token.token"]);`,
+				'  socket.binaryType = "arraybuffer";',
+				"  const binaryLength = await new Promise((resolve, reject) => {",
+				"    socket.onopen = () => queueMicrotask(() => socket.send(new Uint8Array([4, 5, 6])));",
+				"    socket.onmessage = (event) => resolve(event.data.byteLength);",
+				"    socket.onerror = reject;",
+				"  });",
+				"  socket.close();",
+				'  response.writeHead(200, { "Content-Type": "text/event-stream" });',
+				"  response.flushHeaders();",
+				"  response.write(`data: websocket-${binaryLength}\\n\\n`);",
+				"});",
+				'server.listen(3000, "0.0.0.0", () => console.log("READY"));',
+			].join("\n");
+			const child = await vm.spawn("node", ["-e", script], {
+				onStdout: (chunk) => {
+					if (textDecoder.decode(chunk).includes("READY")) resolveReady();
+				},
+				onStderr: (chunk) => {
+					stderr += textDecoder.decode(chunk);
+				},
+			});
+			await Promise.race([
+				ready,
+				vm.process.wait(child.pid).then((result) => {
+					throw new Error(
+						`guest server exited with ${result.exitCode}: ${stderr}`,
+					);
+				}),
+				new Promise<never>((_, reject) =>
+					setTimeout(
+						() => reject(new Error("guest server readiness timed out")),
+						5_000,
+					),
+				),
+			]);
+
+			for (let requestIndex = 0; requestIndex < 10; requestIndex++) {
+				const head = await Promise.race([
+					vm.fetchStreamStart(
+						3000,
+						new Request(`http://guest/events-${requestIndex}`),
+					),
+					new Promise<never>((_, reject) =>
+						setTimeout(
+							() => reject(new Error("stream response head timed out")),
+							5_000,
+						),
+					),
+				]);
+				const chunk = await vm.fetchStreamRead(head.streamId);
+
+				expect(head.status, stderr).toBe(200);
+				expect(textDecoder.decode(chunk.body)).toBe("data: websocket-3\n\n");
+				await vm.fetchStreamCancel(head.streamId);
+			}
+			await vm.process.kill(child.pid, "SIGKILL");
+		} finally {
+			upstreamWebSocket.clients.forEach((socket) => {
+				socket.terminate();
+			});
+			await new Promise<void>((resolve, reject) => {
+				upstreamWebSocket.close((error) => (error ? reject(error) : resolve()));
+			});
+			await new Promise<void>((resolve, reject) => {
+				upstream.close((error) => (error ? reject(error) : resolve()));
+			});
+		}
 	});
 
 	test("supports writeFileSync on an fd from a nested guest child", async () => {
@@ -265,7 +372,7 @@ describe("guest http.request transport", () => {
 			'  await fs.mkdir("/workspace/nested-fs", { recursive: true });',
 			'  const fd = fsSync.openSync("/workspace/nested-fs/session.jsonl", "wx");',
 			'  try { fsSync.writeFileSync(fd, "first\\n"); fsSync.writeFileSync(fd, "second\\n"); }',
-			'  finally { fsSync.closeSync(fd); }',
+			"  finally { fsSync.closeSync(fd); }",
 			'  await fs.writeFile("/workspace/nested-fs/result.txt", "nested-ok", "utf8");',
 			'  console.log(await fs.readFile("/workspace/nested-fs/result.txt", "utf8"));',
 			'  console.log((await fs.readFile("/workspace/nested-fs/session.jsonl", "utf8")).trim());',
@@ -293,7 +400,9 @@ describe("guest http.request transport", () => {
 			response.write("data: first\n\n");
 			setTimeout(() => response.end("data: done\n\n"), 100);
 		});
-		await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+		await new Promise<void>((resolve) =>
+			server.listen(0, "127.0.0.1", resolve),
+		);
 		const address = server.address();
 		if (!address || typeof address === "string") {
 			throw new Error("missing host TCP address");
@@ -363,7 +472,9 @@ describe("guest http.request transport", () => {
 			}
 			response.end();
 		});
-		await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+		await new Promise<void>((resolve) =>
+			server.listen(0, "127.0.0.1", resolve),
+		);
 		const address = server.address();
 		if (!address || typeof address === "string") {
 			throw new Error("missing host TCP address");


### PR DESCRIPTION
- Make the ordinary dispatcher the sole owner of guest execution events while owned VM fetches wake it during async progress.
- Propagate loopback hangups through JavaScript HTTP cleanup so stream cancellation releases peer resources.
- Add repeated WebSocket-dependent streaming coverage and the Node HTTP/2 exports required by the Dynamic Apps reproducer.
- Validate with focused Rust/TypeScript tests and the Dynamic Apps health, metadata, direct HTTP, and SQLite sanity flow.