### PR TITLE
fix(docs): align quickstart steps and icons

### DIFF
--- a/docs/content/docs/browser.mdx
+++ b/docs/content/docs/browser.mdx
@@ -10,48 +10,56 @@ Agents can read and search the web with the [Browserbase](https://www.browserbas
 
 <Steps>
 
-1. **Create a Browserbase account**
+<Step title="Create a Browserbase account">
 
-   [Sign up](https://www.browserbase.com/sign-up) and grab your API key and project id from the [dashboard](https://www.browserbase.com/settings):
+[Sign up](https://www.browserbase.com/sign-up) and grab your API key and project id from the [dashboard](https://www.browserbase.com/settings):
 
-   ```bash
-   export BROWSERBASE_API_KEY=bb_...
-   export BROWSERBASE_PROJECT_ID=...
-   ```
+```bash
+export BROWSERBASE_API_KEY=bb_...
+export BROWSERBASE_PROJECT_ID=...
+```
 
-2. **Install**
+</Step>
 
-   ```bash
-   npm install @rivet-dev/agentos @agentos-software/pi @agentos-software/browserbase
-   ```
+<Step title="Install">
 
-3. **Add `browse` to the VM**
+```bash
+npm install @rivet-dev/agentos @agentos-software/pi @agentos-software/browserbase
+```
 
-   <CodeSnippet file="examples/browserbase/server-minimal.ts" />
+</Step>
 
-   <Accordion title="Optional: install the browse skill">
-     Mount the [`browse` CLI skill](https://github.com/browserbase/stagehand/tree/main/packages/cli) into the agent's skills directory so it reaches for `browse` unprompted ([copy the skill folder from the example](https://github.com/rivet-dev/agentos/tree/main/examples/browserbase/skills)):
+<Step title="Add `browse` to the VM">
 
-     <Tabs>
-     <Tab title="Pi">
-     <CodeSnippet file="examples/browserbase/server-skills-pi.ts" />
-     </Tab>
-     <Tab title="Claude Code">
-     <CodeSnippet file="examples/browserbase/server.ts" />
-     </Tab>
-     </Tabs>
-   </Accordion>
+<CodeSnippet file="examples/browserbase/server-minimal.ts" />
 
-4. **Use it**
+<Accordion title="Optional: install the browse skill">
+Mount the [`browse` CLI skill](https://github.com/browserbase/stagehand/tree/main/packages/cli) into the agent's skills directory so it reaches for `browse` unprompted ([copy the skill folder from the example](https://github.com/rivet-dev/agentos/tree/main/examples/browserbase/skills)):
 
-   <Tabs>
-   <Tab title="Agent uses browse">
-   <CodeSnippet file="examples/browserbase/client-agent.ts" />
-   </Tab>
-   <Tab title="Drive browse directly">
-   <CodeSnippet file="examples/browserbase/client-direct.ts" />
-   </Tab>
-   </Tabs>
+<Tabs>
+<Tab title="Pi">
+<CodeSnippet file="examples/browserbase/server-skills-pi.ts" />
+</Tab>
+<Tab title="Claude Code">
+<CodeSnippet file="examples/browserbase/server.ts" />
+</Tab>
+</Tabs>
+</Accordion>
+
+</Step>
+
+<Step title="Use it">
+
+<Tabs>
+<Tab title="Agent uses browse">
+<CodeSnippet file="examples/browserbase/client-agent.ts" />
+</Tab>
+<Tab title="Drive browse directly">
+<CodeSnippet file="examples/browserbase/client-direct.ts" />
+</Tab>
+</Tabs>
+
+</Step>
 
 </Steps>
 

--- a/docs/content/docs/custom-software/definition.mdx
+++ b/docs/content/docs/custom-software/definition.mdx
@@ -13,25 +13,41 @@ A package is **self-contained**: package it first, then point `defineSoftware()`
 
 <Steps>
 
-1. **You have** C or Rust source for a command. (Most common commands already ship as `@agentos-software/*` packages you can use directly — compile only new or custom ones.)
+<Step title="You have">
 
-2. **Compile it** to WebAssembly — see [Building Binaries](/agentos/docs/custom-software/building-wasm). There's **no `pack` step**: WASM binaries are self-contained, so the compile output is already the package — a `bin/` of `\0asm` files plus a `package.json` for the name/version:
+C or Rust source for a command. (Most common commands already ship as `@agentos-software/*` packages you can use directly — compile only new or custom ones.)
 
-   ```
-   my-cmds/
-   ├── package.json
-   └── bin/
-       ├── tool-a       # \0asm WebAssembly
-       └── tool-b
-   ```
+</Step>
 
-3. **Define it** — point `defineSoftware()` at that directory:
+<Step title="Compile it">
 
-   <CodeSnippet file="examples/software/quickstart-wasm/my-cmds.ts" />
+Compile it to WebAssembly. See [Building Binaries](/agentos/docs/custom-software/building-wasm). There's **no `pack` step**: WASM binaries are self-contained, so the compile output is already the package — a `bin/` of `\0asm` files plus a `package.json` for the name/version:
 
-4. **Use it** — pass it to a VM; the commands are on `$PATH`:
+```
+my-cmds/
+├── package.json
+└── bin/
+    ├── tool-a       # \0asm WebAssembly
+    └── tool-b
+```
 
-   <CodeSnippet file="examples/software/quickstart-wasm/index.ts" />
+</Step>
+
+<Step title="Define it">
+
+Point `defineSoftware()` at that directory:
+
+<CodeSnippet file="examples/software/quickstart-wasm/my-cmds.ts" />
+
+</Step>
+
+<Step title="Use it">
+
+Pass it to a VM. The commands are on `$PATH`:
+
+<CodeSnippet file="examples/software/quickstart-wasm/index.ts" />
+
+</Step>
 
 </Steps>
 
@@ -39,33 +55,49 @@ A package is **self-contained**: package it first, then point `defineSoftware()`
 
 <Steps>
 
-1. **You have** a local project whose `package.json` `bin` names its commands:
+<Step title="You have">
 
-   ```
-   my-tool/
-   ├── package.json     # "bin": { "my-tool": "cli.js" }
-   └── cli.js           # #!/usr/bin/env node
-   ```
+A local project whose `package.json` `bin` names its commands:
 
-2. **Package it** — `pack` installs the full dependency closure into a self-contained package directory (a flat `node_modules` plus a `bin` map of real files):
+```
+my-tool/
+├── package.json     # "bin": { "my-tool": "cli.js" }
+└── cli.js           # #!/usr/bin/env node
+```
 
-   ```bash
-   npx @rivet-dev/agentos-toolchain pack ./my-tool
-   # writes ./my-tool-package/   (override the location with --out <dir>)
-   #   my-tool-package/
-   #   ├── package.json     # "bin": { "my-tool": "node_modules/my-tool/cli.js" }
-   #   └── node_modules/    # flat, self-contained closure
-   ```
+</Step>
 
-   Commands come from the package's `package.json` `bin` map — **real files, no symlinks** — so the result ships cleanly as an npm dependency. (The runtime makes the `/opt/agentos/bin` symlinks itself when it mounts the package.) A native `.node` addon is an error (it can't run in V8); re-run with `--prune-native` to drop unreachable ones.
+<Step title="Package it">
 
-3. **Define it** — point `defineSoftware()` at the packaged directory:
+`pack` installs the full dependency closure into a self-contained package directory (a flat `node_modules` plus a `bin` map of real files):
 
-   <CodeSnippet file="examples/software/quickstart-node/my-tool.ts" />
+```bash
+npx @rivet-dev/agentos-toolchain pack ./my-tool
+# writes ./my-tool-package/   (override the location with --out <dir>)
+#   my-tool-package/
+#   ├── package.json     # "bin": { "my-tool": "node_modules/my-tool/cli.js" }
+#   └── node_modules/    # flat, self-contained closure
+```
 
-4. **Use it** — pass it to a VM; `my-tool` is now on `$PATH`:
+Commands come from the package's `package.json` `bin` map — **real files, no symlinks** — so the result ships cleanly as an npm dependency. (The runtime makes the `/opt/agentos/bin` symlinks itself when it mounts the package.) A native `.node` addon is an error (it can't run in V8); re-run with `--prune-native` to drop unreachable ones.
 
-   <CodeSnippet file="examples/software/quickstart-node/index.ts" />
+</Step>
+
+<Step title="Define it">
+
+Point `defineSoftware()` at the packaged directory:
+
+<CodeSnippet file="examples/software/quickstart-node/my-tool.ts" />
+
+</Step>
+
+<Step title="Use it">
+
+Pass it to a VM. `my-tool` is now on `$PATH`:
+
+<CodeSnippet file="examples/software/quickstart-node/index.ts" />
+
+</Step>
 
 </Steps>
 
@@ -75,22 +107,38 @@ An agent is a Node.js or WASM package (packaged exactly as above) whose `agentos
 
 <Steps>
 
-1. **You have** an npm package with a `bin/` command that speaks ACP over stdio.
+<Step title="You have">
 
-2. **Package it** — same `pack` as Node.js, with `--agent` naming the ACP entrypoint. That writes the `agent` block into the package's `agentos-package.json`:
+An npm package with a `bin/` command that speaks ACP over stdio.
 
-   ```bash
-   npx @rivet-dev/agentos-toolchain pack @scope/my-agent --out ./packages --agent my-agent-acp
-   # → ./packages/my-agent/current   (its agentos-package.json now has the agent block)
-   ```
+</Step>
 
-3. **Define it** — point `defineSoftware()` at the packaged directory; the agent block is already in its `agentos-package.json`:
+<Step title="Package it">
 
-   <CodeSnippet file="examples/software/quickstart-agent/my-agent.ts" />
+Use the same `pack` command as Node.js, with `--agent` naming the ACP entrypoint. That writes the `agent` block into the package's `agentos-package.json`:
 
-4. **Use it** — choose a session ID, then `openSession({ sessionId, agent })` launches the agent by spawning its `acpEntrypoint`:
+```bash
+npx @rivet-dev/agentos-toolchain pack @scope/my-agent --out ./packages --agent my-agent-acp
+# → ./packages/my-agent/current   (its agentos-package.json now has the agent block)
+```
 
-   <CodeSnippet file="examples/software/quickstart-agent/index.ts" />
+</Step>
+
+<Step title="Define it">
+
+Point `defineSoftware()` at the packaged directory. The agent block is already in its `agentos-package.json`:
+
+<CodeSnippet file="examples/software/quickstart-agent/my-agent.ts" />
+
+</Step>
+
+<Step title="Use it">
+
+Choose a session ID, then `openSession({ sessionId, agent })` launches the agent by spawning its `acpEntrypoint`:
+
+<CodeSnippet file="examples/software/quickstart-agent/index.ts" />
+
+</Step>
 
 </Steps>
 

--- a/docs/content/docs/quickstart-embedded.mdx
+++ b/docs/content/docs/quickstart-embedded.mdx
@@ -28,31 +28,41 @@ those responsibilities itself.
 | Agent-to-agent | [Bindings](/agentos/docs/agent-to-agent) between VMs you own | Built into [Rivet Actors](/agentos/docs/agent-to-agent) |
 | Authentication | Your application's own | [Docs](/agentos/docs/authentication) |
 
+## Quick Start
+
 <Steps>
 
-1. **Install**
+<Step title="Install">
 
-   Install the core VM API and the Pi coding agent:
+Install the core VM API and the Pi coding agent:
 
-   ```bash
-   npm install @rivet-dev/agentos-core @agentos-software/pi
-   ```
+```bash
+npm install @rivet-dev/agentos-core @agentos-software/pi
+```
 
-2. **Set your model API key**
+</Step>
 
-   ```bash
-   export ANTHROPIC_API_KEY=your-api-key
-   ```
+<Step title="Set your model API key">
 
-3. **Create an embedded VM**
+```bash
+export ANTHROPIC_API_KEY=your-api-key
+```
 
-   <CodeSnippet file="examples/embedded/quickstart.ts" />
+</Step>
 
-4. **Run it**
+<Step title="Create an embedded VM">
 
-   ```bash
-   npx tsx quickstart.ts
-   ```
+<CodeSnippet file="examples/embedded/quickstart.ts" />
+
+</Step>
+
+<Step title="Run it">
+
+```bash
+npx tsx quickstart.ts
+```
+
+</Step>
 
 </Steps>
 

--- a/docs/content/docs/quickstart.mdx
+++ b/docs/content/docs/quickstart.mdx
@@ -61,59 +61,73 @@ import { AGENT_PROMPT } from '@/data/agentPrompt';
   </g>
 </svg>
 
+## Quick Start
+
 <Steps>
 
-1. **Install**
+<Step title="Install">
 
-   - **@rivet-dev/agentos** — Actor framework with built-in persistence and orchestration
-   - **@agentos-software/pi** — [Pi](https://github.com/mariozechner/pi-coding-agent) coding agent. [Claude Code](/agentos/docs/agents/claude), [Codex](/agentos/docs/agents/codex), and [OpenCode](/agentos/docs/agents/opencode) install the same way.
+- **@rivet-dev/agentos** — Actor framework with built-in persistence and orchestration
+- **@agentos-software/pi** — [Pi](https://github.com/mariozechner/pi-coding-agent) coding agent. [Claude Code](/agentos/docs/agents/claude), [Codex](/agentos/docs/agents/codex), and [OpenCode](/agentos/docs/agents/opencode) install the same way.
 
-   ```bash
-   npm install @rivet-dev/agentos @agentos-software/pi
-   ```
+```bash
+npm install @rivet-dev/agentos @agentos-software/pi
+```
 
-2. **Create the server**
+</Step>
 
-   <CodeSnippet file="examples/quickstart-app/server.ts" />
+<Step title="Create the server">
 
-3. **Create the client**
+<CodeSnippet file="examples/quickstart-app/server.ts" />
 
-   The client can be any public frontend or another backend. The same `vm` actor is reachable from a plain Node script, a browser/React app, or a separate server.
+</Step>
 
-   <CodeGroup>
-   <CodeSnippet file="examples/quickstart-app/client.ts" />
+<Step title="Create the client">
 
-   <CodeSnippet file="examples/quickstart-app/Agent.tsx" />
-   </CodeGroup>
+The client can be any public frontend or another backend. The same `vm` actor is reachable from a plain Node script, a browser/React app, or a separate server.
 
-4. **Run it**
+<CodeGroup>
+<CodeSnippet file="examples/quickstart-app/client.ts" />
 
-   Start the server, then run the client in a second terminal:
+<CodeSnippet file="examples/quickstart-app/Agent.tsx" />
+</CodeGroup>
 
-   ```bash
-   # Terminal 1: start the server
-   npx tsx server.ts
+</Step>
 
-   # Terminal 2: run the client
-   npx tsx client.ts
-   ```
+<Step title="Run it">
 
-   With the server running, open http://localhost:6420/ui to watch the VM in the actor inspector: the live transcript, the filesystem, and its processes.
+Start the server, then run the client in a second terminal:
 
-5. **Customize**
+```bash
+# Terminal 1: start the server
+npx tsx server.ts
 
-   Now that you have a working agent, customize it to fit your needs:
+# Terminal 2: run the client
+npx tsx client.ts
+```
 
-   - **[Software](/agentos/docs/software)** — Install software packages inside the VM
-   - **[Filesystem](/agentos/docs/filesystem)** — Read, write, and manage files inside the VM
-   - **[Permissions & Resource Limits](/agentos/docs/permissions)** — Gate what the agent can do and cap its resource usage
-   - **[Bindings](/agentos/docs/bindings)** — Expose your JavaScript functions to agents as CLI commands
+With the server running, open http://localhost:6420/ui to watch the VM in the actor inspector: the live transcript, the filesystem, and its processes.
 
-5. **Deploy**
+</Step>
 
-   By default, agentOS runs locally with `npx rivetkit dev` — no infrastructure needed. To run in production, deploy to any of these targets:
+<Step title="Customize">
 
-   <Hosting product="agentos" />
+Now that you have a working agent, customize it to fit your needs:
+
+- **[Software](/agentos/docs/software)** — Install software packages inside the VM
+- **[Filesystem](/agentos/docs/filesystem)** — Read, write, and manage files inside the VM
+- **[Permissions & Resource Limits](/agentos/docs/permissions)** — Gate what the agent can do and cap its resource usage
+- **[Bindings](/agentos/docs/bindings)** — Expose your JavaScript functions to agents as CLI commands
+
+</Step>
+
+<Step title="Deploy">
+
+By default, agentOS runs locally with `npx rivetkit dev` — no infrastructure needed. To run in production, deploy to any of these targets:
+
+<Hosting product="agentos" />
+
+</Step>
 
 </Steps>
 

--- a/docs/sidebar.json
+++ b/docs/sidebar.json
@@ -16,7 +16,7 @@
 				{
 					"title": "Quickstart (Embedded)",
 					"href": "/agentos/docs/quickstart-embedded",
-					"icon": "faNodeJs"
+					"icon": "faForwardFast"
 				},
 				{
 					"title": "agentOS vs Sandbox",


### PR DESCRIPTION
- Use the shared Quickstart icon for both Quickstart entries.
- Render guide steps with the standard Steps and Step components.
- Add matching Quick Start section headings to both guides.

Validation: full Rivet website build (406 pages).