### PR TITLE
docs(agentos): document limits and normalize quickstart terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ You don't have to choose: agentOS works with sandboxes through [sandbox mounting
 
 See [agentOS vs Sandbox](https://agentos-sdk.dev/docs/versus-sandbox) for a full comparison.
 
-## Quick start
+## Quickstart
 
 ```bash
 npm install @rivet-dev/agentos @agentos-software/pi

--- a/docs-internal/design/agentos-apps-api-simplification.md
+++ b/docs-internal/design/agentos-apps-api-simplification.md
@@ -792,12 +792,12 @@ paths, and retain the previous valid release during failed iterations.
 - [x] Add the AI SDK generate, type-check, repair, and deploy example.
 - [x] Rewrite the package README around the target API.
 - [x] Rewrite the website Apps page in this order: product overview, checked
-      Hello World quick start, application structure, deployment, builds and
+      Hello World quickstart, application structure, deployment, builds and
       dependencies, HTTP routing, SQLite and RivetKit persistence, scaling and
       cold starts, regions and isolation, examples, API reference, and current
       limitations.
 - [x] Lead the website page with the deployable user API; keep scaler,
-      namespace, artifact, and runner internals after the quick start.
+      namespace, artifact, and runner internals after the quickstart.
 - [x] Source every runnable website snippet from the checked flat examples
       through the docs theme `<CodeSnippet>` mechanism.
 - [x] Include the deployment defaults table, build pipeline, disposable-replica

--- a/docs/content/docs/agents/claude.mdx
+++ b/docs/content/docs/agents/claude.mdx
@@ -4,7 +4,7 @@ description: "Run Claude Code inside an agentOS VM with durable sessions, config
 skill: false
 ---
 
-## Quick start
+## Quickstart
 
 <CodeGroup>
 <CodeSnippet file="examples/claude/server.ts" />

--- a/docs/content/docs/agents/codex.mdx
+++ b/docs/content/docs/agents/codex.mdx
@@ -5,7 +5,7 @@ description: "Run Codex inside an agentOS VM with durable sessions, configurable
 skill: false
 ---
 
-## Quick start
+## Quickstart
 
 <CodeGroup>
 <CodeSnippet file="examples/codex/server.ts" title="server.ts" />

--- a/docs/content/docs/agents/opencode.mdx
+++ b/docs/content/docs/agents/opencode.mdx
@@ -4,7 +4,7 @@ description: "Run OpenCode inside an agentOS VM with durable sessions, configura
 skill: false
 ---
 
-## Quick start
+## Quickstart
 
 <CodeGroup>
 <CodeSnippet file="examples/opencode/server.ts" />

--- a/docs/content/docs/agents/pi.mdx
+++ b/docs/content/docs/agents/pi.mdx
@@ -5,12 +5,12 @@ description: "Run Pi inside an agentOS VM with durable sessions, extensions, cus
 skill: true
 ---
 
-## Quick start
+## Quickstart
 
 <CodeGroup>
 <CodeSnippet file="examples/pi/server.ts" />
 
-<CodeSnippet file="examples/pi/client.ts" region="quick-start" />
+<CodeSnippet file="examples/pi/client.ts" region="quickstart" />
 </CodeGroup>
 
 Read [Sessions](/agentos/docs/sessions) first for session options, streaming events, prompts, and lifecycle management.

--- a/docs/content/docs/resource-limits.mdx
+++ b/docs/content/docs/resource-limits.mdx
@@ -23,7 +23,7 @@ Set caps on the `limits` object in the `agentOS` config. Limits are grouped by s
 |---|---|---|
 | `resources.maxProcesses` | Concurrent processes in the VM process table | Caps fork bombs and runaway spawning. New spawns fail with `EAGAIN`. |
 | `resources.maxOpenFds` | Open file descriptors | Exhausting the table fails with `EMFILE` / `ENFILE`. |
-| `resources.maxSockets` | Open sockets in the socket table | Bounds concurrent connections; excess `connect`/`accept` fail. |
+| `resources.maxSockets` | Open sockets in the socket table | Default is `256`. This includes guest sockets and the sidecar-owned sockets used to send host requests into VM services. Excess socket operations fail instead of consuming more host resources. |
 | `resources.maxFilesystemBytes` | Total bytes stored in the virtual filesystem | Bounds VFS storage; writes past the budget fail with a no-space error. |
 | `resources.maxInodeCount` | Inodes retained by the virtual filesystem | Default is `16384`; creating another file or directory fails with a no-space error. This is the expected upper bound for filesystem-schema sizing and benchmarks. |
 | `resources.maxWasmFuel` | WASM execution budget | Bounds WASM execution work; unset means no explicit fuel budget. |
@@ -52,6 +52,19 @@ Set caps on the `limits` object in the `agentOS` config. Limits are grouped by s
 | `wasm.runnerCpuTimeLimitMs` | Trusted WASI/WASM runner active-CPU budget | Default is `30000`; `0` disables this budget for trusted configurations. |
 | `process.maxSpawnFileActions` | File actions decoded for one `posix_spawn` call | Default is `4096`; excess actions fail with `E2BIG`. |
 | `process.maxSpawnFileActionBytes` | Serialized file-action bytes for one `posix_spawn` call | Default is `1 MiB`; excess input fails with `E2BIG`. |
+
+### Streaming fetch responses
+
+A VM may have at most `256` host-to-VM streaming HTTP responses open at once.
+This is a fixed runtime limit and does not have a `limits` configuration field.
+A stream occupies one slot after `fetchStreamStart()` returns and releases it
+when `fetchStreamRead()` reports `done: true` or the host calls
+`fetchStreamCancel()`. Opening another stream at the limit fails with
+`ERR_AGENTOS_VM_FETCH_STREAM_LIMIT`.
+
+This limit bounds concurrent streams, not the number of requests a warm VM can
+serve over its lifetime. Completed and cancelled streams do not accumulate
+toward the limit.
 
 ## Behavior at the limit
 

--- a/examples/claude/client.ts
+++ b/examples/claude/client.ts
@@ -6,7 +6,7 @@ const client = createClient<typeof registry>({
 });
 const agent = client.vm.getOrCreate("my-agent");
 
-// ── Quick start ───────────────────────────────────────────────────
+// ── Quickstart ────────────────────────────────────────────────────
 async function quickStart() {
 	// docs:start quickstart
 	await agent.sessions.open({

--- a/examples/codex/client.ts
+++ b/examples/codex/client.ts
@@ -7,7 +7,7 @@ const client = createClient<typeof registry>({
 });
 const agent = client.vm.getOrCreate("my-agent");
 
-// ── Quick start ───────────────────────────────────────────────────
+// ── Quickstart ────────────────────────────────────────────────────
 async function quickStart() {
 	await agent.sessions.open({
 		agent: "codex",

--- a/examples/opencode/client.ts
+++ b/examples/opencode/client.ts
@@ -6,7 +6,7 @@ const client = createClient<typeof registry>({
 });
 const agent = client.vm.getOrCreate("my-agent");
 
-// ── Quick start ───────────────────────────────────────────────────
+// ── Quickstart ────────────────────────────────────────────────────
 async function quickStart() {
 	// docs:start quickstart
 	await agent.sessions.open({

--- a/examples/pi/README.md
+++ b/examples/pi/README.md
@@ -1,11 +1,11 @@
 ---
 title: "Pi Agent"
-description: "Run the Pi coding agent in a session, including quick start and session management."
+description: "Run the Pi coding agent in a session, including quickstart and session management."
 category: "Agents"
 order: 1
 ---
 
-Spin up the Pi coding agent inside a VM, open a session, and send it prompts. Reach for this when you want an end-to-end agent loop — quick start plus the session knobs for skills and MCP servers.
+Spin up the Pi coding agent inside a VM, open a session, and send it prompts. Reach for this when you want an end-to-end agent loop from quickstart through the session knobs for skills and MCP servers.
 
 ## How it works
 

--- a/examples/pi/client.ts
+++ b/examples/pi/client.ts
@@ -6,8 +6,8 @@ const client = createClient<typeof registry>({
 });
 const agent = client.vm.getOrCreate("my-agent");
 
-// ── Quick start ───────────────────────────────────────────────────
-// docs:start quick-start
+// ── Quickstart ────────────────────────────────────────────────────
+// docs:start quickstart
 async function quickStart() {
 	await agent.sessions.open({
 		agent: "pi",
@@ -21,7 +21,7 @@ async function quickStart() {
 	});
 	console.log(result.message?.content ?? []);
 }
-// docs:end quick-start
+// docs:end quickstart
 
 // ── Skills ────────────────────────────────────────────────────────
 //


### PR DESCRIPTION
- Document the configurable socket limit and fixed streaming-fetch concurrency limit.
- Standardize quickstart terminology across public docs, examples, and internal guidance.