### PR TITLE
fix(runtime): deliver JS process stdout/stderr to a redirected fd (pipe/file)

### DIFF
--- a/packages/build-tools/bridge-src/builtins/console.ts
+++ b/packages/build-tools/bridge-src/builtins/console.ts
@@ -173,8 +173,22 @@ function createStdioWriteStream(options) {
   return stream;
 }
 
+// Route guest stdout/stderr through the kernel stdio bridge (fd 1/2) so
+// redirection and pipes are honored — `node ... | cat`, `node ... > file`, and
+// any dup2 of fd 1/2 must reach the real descriptor, exactly like a WASM stage.
+// The legacy `_log`/`_error` path appends to the process's *captured* output
+// and bypasses fd 1/2, so it silently drops output whenever stdout/stderr is
+// redirected. Fall back to it only when the kernel bridge is unavailable.
+function _kernelStdioWrite(fd, data) {
+  if (typeof _kernelStdioWriteRaw === "undefined") return false;
+  const bytes = data instanceof Uint8Array ? data : new TextEncoder().encode(String(data));
+  _kernelStdioWriteRaw.applySync(void 0, [fd, bytes]);
+  return true;
+}
+
 var _stdout = createStdioWriteStream({
   write(data) {
+    if (_kernelStdioWrite(1, data)) return;
     if (typeof _log !== "undefined") {
       _log.applySync(void 0, [data]);
     }
@@ -184,6 +198,7 @@ var _stdout = createStdioWriteStream({
 
 var _stderr = createStdioWriteStream({
   write(data) {
+    if (_kernelStdioWrite(2, data)) return;
     if (typeof _error !== "undefined") {
       _error.applySync(void 0, [data]);
     }


### PR DESCRIPTION
Guest process.stdout/process.stderr (and console.log/error) wrote via the _log/_error bridge globals, which append to the process's *captured* output and bypass kernel fd 1/2. So any redirection was silently dropped: 'node -e ... | cat' produced empty output (wc -c saw 0 bytes) and 'node -e ... > file' wrote nothing, while fs.writeSync(1, ...) — which goes through the kernel fd — worked. Confirmed pre-existing on 0.2.20-rc.1.

Route _stdout/_stderr through the existing _kernelStdioWriteRaw bridge (__kernel_stdio_write -> write_process_stdout/stderr on kernel fd 1/2), the same path WASM stages use, so redirection and pipes are honored. Falls back to _log/_error only when the kernel bridge is unavailable (e.g. browser). Top-level captured output is unchanged (the sidecar drains fd 1).

Verified: process.stdout|cat, console.log|cat, node|wc -c (6 bytes), node>file, console.error 2>&1|cat all deliver output; top-level node output and the #1959 pipelines are unaffected. Note: the symmetric stdin-stream gap (process.stdin does not emit 'data' from a piped fd 0, though fs.readSync(0) works) is a separate follow-up.