### PR TITLE
chore: add The Company Company environment config

### DIFF
--- a/.company/environment.json
+++ b/.company/environment.json
@@ -2,7 +2,7 @@
 	"$schema": "https://api.thecompany.company/schemas/v1/environment.json",
 	"scripts": {
 		"install": {
-			"command": "set -euo pipefail\nexport DEBIAN_FRONTEND=noninteractive\nsudo apt-get update -y\nsudo apt-get install -y --no-install-recommends ca-certificates curl gnupg xz-utils binutils sccache build-essential pkg-config libssl-dev make git\ncurl -fsSL https://deb.nodesource.com/setup_24.x | sudo -E bash -\nsudo apt-get install -y --no-install-recommends nodejs\nsudo corepack enable\ncurl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --component rustfmt,clippy\nrustup toolchain install nightly --component rust-src --target wasm32-wasip1\nsudo ln -sf \"$HOME\"/.cargo/bin/* /usr/local/bin/\npnpm install --frozen-lockfile\ncargo fetch --locked",
+			"command": "set -euo pipefail\nexport DEBIAN_FRONTEND=noninteractive\nsudo apt-get update -y\nsudo apt-get install -y --no-install-recommends ca-certificates curl gnupg xz-utils binutils sccache build-essential pkg-config libssl-dev make git\ncurl -fsSL https://deb.nodesource.com/setup_24.x | sudo -E bash -\nsudo apt-get install -y --no-install-recommends nodejs\nsudo corepack enable\ncurl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --component rustfmt,clippy\nsudo ln -sf \"$HOME\"/.cargo/bin/* /usr/local/bin/\nrustup toolchain install nightly --component rust-src --target wasm32-wasip1\npnpm install --frozen-lockfile\ncargo fetch --locked",
 			"timeout": 3600
 		},
 		"prepare": {

--- a/.company/environment.json
+++ b/.company/environment.json
@@ -1,0 +1,18 @@
+{
+	"$schema": "https://api.thecompany.company/schemas/v1/environment.json",
+	"scripts": {
+		"install": {
+			"command": "set -euo pipefail\nexport DEBIAN_FRONTEND=noninteractive\nsudo apt-get update -y\nsudo apt-get install -y --no-install-recommends ca-certificates curl gnupg xz-utils binutils sccache build-essential pkg-config libssl-dev make git\ncurl -fsSL https://deb.nodesource.com/setup_24.x | sudo -E bash -\nsudo apt-get install -y --no-install-recommends nodejs\nsudo corepack enable\ncurl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --component rustfmt,clippy\nrustup toolchain install nightly --component rust-src --target wasm32-wasip1\nsudo ln -sf \"$HOME\"/.cargo/bin/* /usr/local/bin/\npnpm install --frozen-lockfile\ncargo fetch --locked",
+			"timeout": 3600
+		},
+		"prepare": {
+			"command": "set -euo pipefail\npnpm install --frozen-lockfile\ncargo fetch --locked",
+			"timeout": 900
+		}
+	},
+	"env": {
+		"COREPACK_ENABLE_DOWNLOAD_PROMPT": "0",
+		"CARGO_NET_GIT_FETCH_WITH_CLI": "true",
+		"AGENTOS_SKIP_NATIVE_META_BUILD": "1"
+	}
+}


### PR DESCRIPTION
Adds `.company/environment.json` so The Company Company can build and run this repo in cloud environments.

- `install`: native build deps (sccache, binutils, pkg-config, OpenSSL), Node 24 via NodeSource, pnpm via corepack, Rust stable with rustfmt + clippy, nightly with `rust-src` and the `wasm32-wasip1` target for the `-Z build-std` software toolchain, `pnpm install --frozen-lockfile`, `cargo fetch --locked`
- `prepare`: fast idempotent reconcile, `pnpm install --frozen-lockfile` + `cargo fetch --locked`
- `env`: `AGENTOS_SKIP_NATIVE_META_BUILD=1` (matches CI) and `CARGO_NET_GIT_FETCH_WITH_CLI=true`, plus non-interactive corepack

Verified by running the install command to exit 0 in a clean Ubuntu 24.04 sandbox.