### PR TITLE
fix(browserbase): handle optional command output

### DIFF
--- a/examples/browserbase/client-direct.ts
+++ b/examples/browserbase/client-direct.ts
@@ -17,8 +17,12 @@ const env = {
 
 const { stdout } = await agent.process.exec("browse cloud fetch https://example.com", {
 	env,
+	output: { capture: "all" },
 });
+if (!stdout) {
+	throw new Error("Browserbase command returned no output");
+}
 
-const page = JSON.parse(stdout!) as { statusCode: number; content: string };
+const page = JSON.parse(stdout) as { statusCode: number; content: string };
 console.log(`fetched status ${page.statusCode}`);
 console.log(page.content);

--- a/examples/browserbase/client-direct.ts
+++ b/examples/browserbase/client-direct.ts
@@ -19,6 +19,6 @@ const { stdout } = await agent.process.exec("browse cloud fetch https://example.
 	env,
 });
 
-const page = JSON.parse(stdout) as { statusCode: number; content: string };
+const page = JSON.parse(stdout!) as { statusCode: number; content: string };
 console.log(`fetched status ${page.statusCode}`);
 console.log(page.content);

--- a/examples/browserbase/client.ts
+++ b/examples/browserbase/client.ts
@@ -20,7 +20,7 @@ const { stdout } = await agent.process.exec("browse cloud fetch https://example.
 	env,
 });
 
-const page = JSON.parse(stdout) as { statusCode: number; content: string };
+const page = JSON.parse(stdout!) as { statusCode: number; content: string };
 console.log(`fetched status ${page.statusCode}`);
 console.log(page.content);
 

--- a/examples/browserbase/client.ts
+++ b/examples/browserbase/client.ts
@@ -18,9 +18,13 @@ const env = {
 
 const { stdout } = await agent.process.exec("browse cloud fetch https://example.com", {
 	env,
+	output: { capture: "all" },
 });
+if (!stdout) {
+	throw new Error("Browserbase command returned no output");
+}
 
-const page = JSON.parse(stdout!) as { statusCode: number; content: string };
+const page = JSON.parse(stdout) as { statusCode: number; content: string };
 console.log(`fetched status ${page.statusCode}`);
 console.log(page.content);
 


### PR DESCRIPTION
- Assert command output is present before parsing the Browserbase response.
- Restore the browserbase example typecheck under strict TypeScript settings.