### PR TITLE
fix(client): allow execution submission enum layout

### DIFF
--- a/crates/client/src/language_execution.rs
+++ b/crates/client/src/language_execution.rs
@@ -156,6 +156,7 @@ pub struct TypeScriptCheckResult {
     pub diagnostics: Vec<TypeScriptDiagnostic>,
 }
 
+#[allow(clippy::large_enum_variant)] // This private enum avoids an allocation on the synchronous completion path.
 #[derive(Debug, Clone)]
 enum ExecutionSubmission {
     Completed(CodeExecutionResult),

--- a/crates/kernel/src/kernel.rs
+++ b/crates/kernel/src/kernel.rs
@@ -9214,8 +9214,10 @@ impl PosixAcl {
         if version != POSIX_ACL_XATTR_VERSION {
             return Err(invalid_acl(path, "unsupported xattr version"));
         }
-        let entries = value[4..]
-            .chunks_exact(8)
+        let (chunks, remainder) = value[4..].as_chunks::<8>();
+        debug_assert!(remainder.is_empty());
+        let entries = chunks
+            .iter()
             .map(|bytes| PosixAclEntry {
                 tag: u16::from_le_bytes([bytes[0], bytes[1]]),
                 perm: u16::from_le_bytes([bytes[2], bytes[3]]),


### PR DESCRIPTION
- Allow the private execution submission enum layout under Rust 1.98 clippy.
- Avoid boxing the synchronous completion result and its additional allocation.