### PR TITLE
fix(client): update OpenCode E2E execution calls

### DIFF
--- a/crates/client/tests/loopback_probe_e2e.rs
+++ b/crates/client/tests/loopback_probe_e2e.rs
@@ -5,7 +5,8 @@
 //! all guest HTTP, including agent SDK -> LLM traffic).
 mod common;
 use agentos_client::config::{AgentOsConfig, PatternPermissions, PermissionMode, Permissions};
-use agentos_client::ExecOptions;
+use agentos_client::language_execution::{ExecutionOutputOptions, OutputCapture};
+use agentos_client::LanguageExecutionOptions;
 use std::io::Write;
 use std::time::Duration;
 
@@ -45,17 +46,32 @@ async fn guest_fetch_reaches_host_loopback() {
     let args = vec![String::from("-e"), script];
     let result = tokio::time::timeout(
         Duration::from_secs(15),
-        os.exec_argv("node", &args, ExecOptions::default()),
+        os.exec_argv(
+            "node",
+            args,
+            LanguageExecutionOptions {
+                output: ExecutionOutputOptions {
+                    capture: OutputCapture::All,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        ),
     )
     .await
     .expect("guest fetch timed out")
     .expect("exec");
     println!(
-        "exit={} stdout={:?} stderr={:?}",
+        "exit={:?} stdout={:?} stderr={:?}",
         result.exit_code, result.stdout, result.stderr
     );
     assert!(
-        result.stdout.contains("PROBE_PONG"),
+        result
+            .stdout
+            .as_deref()
+            .unwrap_or_default()
+            .windows(b"PROBE_PONG".len())
+            .any(|window| window == b"PROBE_PONG"),
         "stdout={:?} stderr={:?}",
         result.stdout,
         result.stderr

--- a/crates/client/tests/opencode_session_e2e.rs
+++ b/crates/client/tests/opencode_session_e2e.rs
@@ -18,7 +18,8 @@ use agentos_client::config::{
 };
 use agentos_client::fs::MkdirOptions;
 use agentos_client::{
-    AgentOs, ContentBlock, ExecOptions, ListSessionsInput, OpenSessionInput, PromptInput,
+    AgentOs, ContentBlock, LanguageExecutionOptions, ListSessionsInput, OpenSessionInput,
+    PromptInput,
 };
 
 const LLMOCK_SENTINEL: &str = "PONG_FROM_LLMOCK";
@@ -167,7 +168,7 @@ async fn packed_opencode_initializes_and_creates_session() {
     let temp_dir_probe = os
         .exec_argv(
             "node",
-            &[
+            vec![
                 "-e".to_string(),
                 r#"(async () => {
 const { mkdtemp } = require("node:fs");
@@ -185,22 +186,26 @@ console.log(JSON.stringify({
 })();"#
                     .to_string(),
             ],
-            ExecOptions::default(),
+            LanguageExecutionOptions::default(),
         )
         .await
         .expect("run Node fs.mkdtemp compatibility probe");
     assert_eq!(
-        temp_dir_probe.exit_code, 0,
+        temp_dir_probe.exit_code,
+        Some(0),
         "node:fs mkdtemp failed: stdout={:?} stderr={:?}",
-        temp_dir_probe.stdout, temp_dir_probe.stderr
+        temp_dir_probe.stdout,
+        temp_dir_probe.stderr
     );
     assert!(
-        temp_dir_probe.stdout.contains(r#""error":null"#),
+        String::from_utf8_lossy(temp_dir_probe.stdout.as_deref().unwrap_or_default())
+            .contains(r#""error":null"#),
         "node:fs mkdtemp callback returned an error: {:?}",
         temp_dir_probe.stdout
     );
     assert!(
-        temp_dir_probe.stdout.contains(r#""esmOpen":"function""#),
+        String::from_utf8_lossy(temp_dir_probe.stdout.as_deref().unwrap_or_default())
+            .contains(r#""esmOpen":"function""#),
         "node:fs ESM namespace omitted open(): {:?}",
         temp_dir_probe.stdout
     );
@@ -245,7 +250,7 @@ console.log(JSON.stringify({
         let log = os
             .exec_argv(
                 "node",
-                &[
+                vec![
                     "-e".to_string(),
                     r#"const fs = require("node:fs");
 const path = "/home/agentos/.local/share/opencode/log/opencode.log";
@@ -255,7 +260,7 @@ try {
 catch (error) { process.stderr.write(String(error)); process.exitCode = 1; }"#
                         .to_string(),
                 ],
-                ExecOptions::default(),
+                LanguageExecutionOptions::default(),
             )
             .await
             .expect("read OpenCode diagnostic log");
@@ -326,14 +331,14 @@ catch (error) { process.stderr.write(String(error)); process.exitCode = 1; }"#
         let log = os
             .exec_argv(
                 "node",
-                &[
+                vec![
                     "-e".to_string(),
                     r#"const fs = require("node:fs");
 const path = "/home/agentos/.local/share/opencode/log/opencode.log";
 process.stdout.write(fs.readFileSync(path, "utf8"));"#
                         .to_string(),
                 ],
-                ExecOptions::default(),
+                LanguageExecutionOptions::default(),
             )
             .await
             .expect("read OpenCode empty prompt log");

--- a/crates/client/tests/opencode_session_e2e.rs
+++ b/crates/client/tests/opencode_session_e2e.rs
@@ -24,6 +24,16 @@ use agentos_client::{
 
 const LLMOCK_SENTINEL: &str = "PONG_FROM_LLMOCK";
 
+fn captured_execution_options() -> LanguageExecutionOptions {
+    LanguageExecutionOptions {
+        output: agentos_client::language_execution::ExecutionOutputOptions {
+            capture: agentos_client::language_execution::OutputCapture::All,
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
+
 fn repo_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("../..")
@@ -186,7 +196,7 @@ console.log(JSON.stringify({
 })();"#
                     .to_string(),
             ],
-            LanguageExecutionOptions::default(),
+            captured_execution_options(),
         )
         .await
         .expect("run Node fs.mkdtemp compatibility probe");
@@ -260,7 +270,7 @@ try {
 catch (error) { process.stderr.write(String(error)); process.exitCode = 1; }"#
                         .to_string(),
                 ],
-                LanguageExecutionOptions::default(),
+                captured_execution_options(),
             )
             .await
             .expect("read OpenCode diagnostic log");
@@ -338,7 +348,7 @@ const path = "/home/agentos/.local/share/opencode/log/opencode.log";
 process.stdout.write(fs.readFileSync(path, "utf8"));"#
                         .to_string(),
                 ],
-                LanguageExecutionOptions::default(),
+                captured_execution_options(),
             )
             .await
             .expect("read OpenCode empty prompt log");


### PR DESCRIPTION
- Update OpenCode E2E execution calls to the current client API.
- Handle optional execution exit codes and captured output in assertions.